### PR TITLE
Retry build clean step on transient Windows file locks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reactionbot",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reactionbot",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "dependencies": {
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2"
@@ -15,7 +15,7 @@
         "@eslint/js": "^9.39.5",
         "eslint": "^9.39.5",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-jsdoc": "^63.2.1",
+        "eslint-plugin-jsdoc": "^63.2.2",
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.7.0",
         "lint-staged": "^17.2.0",
@@ -164,9 +164,9 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.89.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.89.0.tgz",
-      "integrity": "sha512-ESopDL0Bvyak+X5FQHlWkesK3TO2WNZOV5d4Rh4ouaZxekla9P8e7boSZpmxeTWQ0sTwcAp9h5eAeD1kZ9ywvA==",
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.90.0.tgz",
+      "integrity": "sha512-51x9KxyTAN6guZOCd+lmcDdkhgdMdP/6iMMtg9dyhCWDc3+iSUyoB7f/9WAM/yGHmGFq25Vd6bXRR7CZcB+tog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -174,7 +174,7 @@
         "@typescript-eslint/types": "^8.65.0",
         "comment-parser": "1.4.7",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.2.0"
+        "jsdoc-type-pratt-parser": "~7.3.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -1847,13 +1847,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.2.1.tgz",
-      "integrity": "sha512-4aPJDFGAIYq81kifBPvInvSHdAwowJ+nVXvSEoBC5SKzdr5Em9NFaVkdPX7UbVUyNN2Zn8JvQB+daNf3wSQE8Q==",
+      "version": "63.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.2.2.tgz",
+      "integrity": "sha512-xCoHKeaRwAhZ+i2ZUY11few2Lmy9qpJLDsY139c4KNJLMSZYoFJ5UMYkDjdTkO9PfkFOKmVO+7i4Yjx+x7VQWQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.89.0",
+        "@es-joy/jsdoccomment": "~0.90.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.7",
@@ -2483,9 +2483,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
-      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.3.0.tgz",
+      "integrity": "sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "reactionbot",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "type": "module",
   "scripts": {
-    "build": "node -e \"fs.rmSync('build',{recursive:true,force:true});fs.rmSync('tsconfig.tsbuildinfo',{force:true})\" && tsc && tsc-alias",
+    "build": "node -e \"fs.rmSync('build',{recursive:true,force:true,maxRetries:10,retryDelay:200});fs.rmSync('tsconfig.tsbuildinfo',{force:true})\" && tsc && tsc-alias",
     "dev": "tsx watch src/index.ts",
     "format": "prettier --write \"**/*.{js,mjs,cjs,ts,md,json,yml,yaml}\"",
     "lint": "eslint \"{src,scripts}/**/*.{js,ts}\" --fix",
@@ -31,7 +31,7 @@
     "@eslint/js": "^9.39.5",
     "eslint": "^9.39.5",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-jsdoc": "^63.2.1",
+    "eslint-plugin-jsdoc": "^63.2.2",
     "eslint-plugin-prettier": "^5.5.6",
     "globals": "^17.7.0",
     "lint-staged": "^17.2.0",


### PR DESCRIPTION
## Summary
- Add `maxRetries`/`retryDelay` to the `rmSync` clean step in `npm run build` so transient Windows EPERM file locks are retried instead of failing the build immediately
- Bump eslint-plugin-jsdoc to 63.2.2
- Bump version to 3.0.1