### PR TITLE
Offer a Copy button on the media move prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reactionbot",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reactionbot",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "dependencies": {
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2"
@@ -18,7 +18,7 @@
         "eslint-plugin-jsdoc": "^63.3.2",
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.8.0",
-        "lint-staged": "^17.2.0",
+        "lint-staged": "^17.3.0",
         "prettier": "^3.9.6",
         "prettier-plugin-organize-imports": "^4.3.0",
         "prettier-plugin-packagejson": "^3.0.2",
@@ -2202,9 +2202,9 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.2.0.tgz",
-      "integrity": "sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
+      "integrity": "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactionbot",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "type": "module",
   "scripts": {
     "build": "node -e \"fs.rmSync('build',{recursive:true,force:true,maxRetries:10,retryDelay:200});fs.rmSync('tsconfig.tsbuildinfo',{force:true})\" && tsc && tsc-alias",
@@ -34,7 +34,7 @@
     "eslint-plugin-jsdoc": "^63.3.2",
     "eslint-plugin-prettier": "^5.5.6",
     "globals": "^17.8.0",
-    "lint-staged": "^17.2.0",
+    "lint-staged": "^17.3.0",
     "prettier": "^3.9.6",
     "prettier-plugin-organize-imports": "^4.3.0",
     "prettier-plugin-packagejson": "^3.0.2",

--- a/readme.md
+++ b/readme.md
@@ -8,14 +8,15 @@ per-server counters for swears, slurs, and name-calling.
 
 ## Features
 
-- **Media link relocation**: detect link > Yes/No approval prompt for the author (configurable
-  grace, including instant auto-move) > delete the original > repost the rewritten link in the media
-  channel > leave a pointer "tail" in the source channel. The full message text and any attachments
-  are carried over, and anyone the message tagged is named on the tail too ("SENT SLOP TO ...") -
-  mentions render without pinging. The author can change a moved post by right-clicking it - or its
-  tail - and picking **Apps > Edit post** (a popup pre-filled with the text) or **Apps > Delete
-  post** (removes the post and its tail together). Records are persisted, so both keep working after
-  bot restarts. Links edited into an existing message are caught too.
+- **Media link relocation**: detect link > Yes/Copy/No prompt for the author (configurable grace,
+  including instant auto-move) > delete the original > repost the rewritten link in the media
+  channel > leave a pointer "tail" in the source channel. **Copy** is the quiet way out: the author
+  gets the embeddable link privately and their message is left exactly where it is. The full message
+  text and any attachments are carried over, and anyone the message tagged is named on the tail too
+  ("SENT SLOP TO ...") - mentions render without pinging. The author can change a moved post by
+  right-clicking it - or its tail - and picking **Apps > Edit post** (a popup pre-filled with the
+  text) or **Apps > Delete post** (removes the post and its tail together). Records are persisted,
+  so both keep working after bot restarts. Links edited into an existing message are caught too.
 - **Embed-friendly rewrites**: URLs are swapped to frontends that actually embed in Discord (see
   `FRONTENDS` in [src/media/transform.ts](src/media/transform.ts)).
 - **Pre-fixed links move too**: links already on a fixer frontend (fxtwitter, cunnyx, ddinstagram,
@@ -23,9 +24,9 @@ per-server counters for swears, slurs, and name-calling.
   moved to the media channel as-is, without rewriting (see `PRE_EMBEDDED_REGEX` in
   [src/regex.ts](src/regex.ts)).
 - **Tracking-junk cleaning**: social links get their `?utm_...`/`fbclid`-style tails dropped
-  automatically during the rewrite; any other link carrying known trackers gets a Yes/No prompt to
-  clean it in place (it stays in its channel). Functional params (`v=`, timestamps, share ids in
-  paths) are never touched - see the conservative list in
+  automatically during the rewrite; any other link carrying known trackers gets a Repost/Copy/No
+  prompt to clean it in place (it stays in its channel). Functional params (`v=`, timestamps, share
+  ids in paths) are never touched - see the conservative list in
   [src/media/cleanTracking.ts](src/media/cleanTracking.ts).
 - **Trackers**: per-guild counters for swears (insults included) and slurs (with targeted-group
   breakdown), with leaderboard commands.

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -237,11 +237,19 @@ function checkLinkTransforms(): void {
     "returns null when nothing to strip",
     stripTracking("https://example.com/p?id=7") === null,
   );
-  const tracked = matchAny("look https://example.com/article?utm_source=news&si=abc123");
+  // Short, widely-reused keys are left alone: a site can legitimately mean
+  // something functional by them, and a wrong strip breaks the link.
+  check(
+    "tracking",
+    "generic keys are not treated as trackers",
+    stripTracking("https://example.com/p?si=1&ref_url=2&share_id=3&spm=4") === null,
+  );
+  const tracked = matchAny("look https://example.com/article?utm_source=news&fbclid=abc123&id=7");
   check(
     "tracking",
     "tracked link matches as 'tracking' with the cleaned URL",
-    tracked?.which === "tracking" && buildTransformedUrl(tracked) === "https://example.com/article",
+    tracked?.which === "tracking" &&
+      buildTransformedUrl(tracked) === "https://example.com/article?id=7",
   );
   const socialTail = matchAny("https://x.com/u/status/1?s=20&t=trackme");
   check(

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -10,7 +10,8 @@ import { data as deletePost } from "@/commands/deletepost";
 import { data as editPost } from "@/commands/editpost";
 import { resolveGrace } from "@/commands/setdelay";
 import { data as slursCommand } from "@/commands/slurs";
-import { buildCopyMessage, stripTracking } from "@/media/cleanTracking";
+import { stripTracking } from "@/media/cleanTracking";
+import { buildCopyMessage } from "@/media/copyLink";
 import { matchAny } from "@/media/match";
 import { buildMovedContent, buildPointerContent, collectMentions } from "@/media/repost";
 import { findRepostForMessage, getRepost, removeRepost, saveRepost } from "@/media/repostStore";
@@ -300,8 +301,8 @@ function checkRepostContent(): void {
   const clean = "https://example.com/x?v=1";
   check(
     "repost",
-    "copy hand-off fences the cleaned link",
-    buildCopyMessage(clean).includes(`\`\`\`\n${clean}\n\`\`\``),
+    "copy hand-off fences the link under its lead line",
+    buildCopyMessage(clean, "Here you go:") === `Here you go:\n\`\`\`\n${clean}\n\`\`\``,
   );
 }
 

--- a/src/media/approval.ts
+++ b/src/media/approval.ts
@@ -1,8 +1,7 @@
 // src/media/approval.ts
 
-// Button prompts with grace handling. requestChoice is the generic core (any
-// button set, returns which was clicked); requestApproval is the yes/no case
-// built on it. Only the intended author's clicks count.
+// Button prompts with grace handling: requestChoice takes any button set and
+// returns which one was clicked. Only the intended author's clicks count.
 
 import { ApprovalOptions, GraceSetting } from "@/media/types";
 import { createLogger } from "@/utils/log";
@@ -134,30 +133,4 @@ export async function requestChoice(
       resolve({ choice, interaction: clicked });
     });
   });
-}
-
-/**
- * Request in-channel approval from a user via Yes/No buttons. Thin wrapper
- * over {@link requestChoice}: resolves `true` on "Yes", `false` on "No" or
- * timeout, and `true` immediately when `grace` is `"instant"`.
- * @param channel - Target channel for the prompt.
- * @param author - Allowed responder.
- * @param [opts] - Prompt and behaviour controls.
- * @returns Approval result.
- */
-export async function requestApproval(
-  channel: GuildTextBasedChannel,
-  author: User,
-  opts: ApprovalOptions = {},
-): Promise<boolean> {
-  const { choice } = await requestChoice(
-    channel,
-    author,
-    [
-      { id: "yes", label: "Yes", style: ButtonStyle.Success },
-      { id: "no", label: "No", style: ButtonStyle.Danger },
-    ],
-    { ...opts, instantChoice: "yes" },
-  );
-  return choice === "yes";
 }

--- a/src/media/cleanTracking.ts
+++ b/src/media/cleanTracking.ts
@@ -63,14 +63,3 @@ export function stripTracking(url: string): string | null {
   if (out.endsWith("?")) out = out.slice(0, -1);
   return out;
 }
-
-/**
- * Builds the private reply handing the poster their cleaned link. The URL sits
- * in a fenced block so Discord renders no embed and mobile clients show a copy
- * button.
- * @param cleanUrl - The URL with tracking parameters removed.
- * @returns The message content to send.
- */
-export function buildCopyMessage(cleanUrl: string): string {
-  return `Here's your link without the tracking junk:\n\`\`\`\n${cleanUrl}\n\`\`\``;
-}

--- a/src/media/cleanTracking.ts
+++ b/src/media/cleanTracking.ts
@@ -23,13 +23,8 @@ const TRACKING_PARAMS = new Set([
   "vero_id",
   "igsh",
   "igshid",
-  "si",
-  "spm",
-  "ref_src",
-  "ref_url",
   "cmpid",
   "s_cid",
-  "share_id",
 ]);
 
 /** Param-name prefixes that are always tracking (utm_source, _hsenc, ...). */

--- a/src/media/copyLink.ts
+++ b/src/media/copyLink.ts
@@ -1,0 +1,15 @@
+// src/media/copyLink.ts
+
+// Builds the private hand-over that gives a poster a rewritten link instead of
+// touching their message, shared by the media and tracking-clean prompts.
+
+/**
+ * Builds the private reply handing the poster a link. The URL sits in a fenced
+ * block so Discord renders no embed and mobile clients show a copy button.
+ * @param url - The link to hand over.
+ * @param lead - Line shown above the fenced URL, naming what was done to it.
+ * @returns The message content to send.
+ */
+export function buildCopyMessage(url: string, lead: string): string {
+  return `${lead}\n\`\`\`\n${url}\n\`\`\``;
+}

--- a/src/media/workflow.ts
+++ b/src/media/workflow.ts
@@ -3,28 +3,73 @@
 // Orchestrates media-link handling for a single message. Splits
 // responsibilities across match/transform/settings/approval/repost/audit.
 
-import { ChoiceButton, requestApproval, requestChoice } from "@/media/approval";
-import { buildCopyMessage } from "@/media/cleanTracking";
+import { ChoiceButton, requestChoice } from "@/media/approval";
+import { buildCopyMessage } from "@/media/copyLink";
 import { matchAny } from "@/media/match";
 import { repostWithOptionalStub } from "@/media/repost";
 import { registerRepostActions } from "@/media/repostActions";
 import { loadSettings, resolveApprovalPlan, resolveTargetChannelId } from "@/media/settings";
 import { rewriteContent } from "@/media/transform";
 import { createLogger } from "@/utils/log";
-import { ButtonStyle, GuildTextBasedChannel, Message, MessageFlags } from "discord.js";
+import {
+  ButtonInteraction,
+  ButtonStyle,
+  GuildTextBasedChannel,
+  Message,
+  MessageFlags,
+} from "discord.js";
 
 const log = createLogger("media/workflow");
 
 /**
- * Buttons on the tracking-clean prompt. "Copy" hands the poster the cleaned
- * link privately and leaves their message alone; "Repost" is the move-and-
- * rewrite path shared with media links.
+ * Buttons on the tracking-clean prompt. "Repost" is the move-and-rewrite path
+ * shared with media links.
  */
 const CLEAN_BUTTONS: ChoiceButton[] = [
-  { id: "repost", label: "Repost", emoji: "♻️", style: ButtonStyle.Primary },
+  { id: "yes", label: "Repost", emoji: "♻️", style: ButtonStyle.Primary },
   { id: "copy", label: "Copy", emoji: "📋", style: ButtonStyle.Secondary },
   { id: "no", label: "No", style: ButtonStyle.Danger },
 ];
+
+/** Buttons on the media prompt, both when moving channels and rewriting in place. */
+const MEDIA_BUTTONS: ChoiceButton[] = [
+  { id: "yes", label: "Yes", style: ButtonStyle.Success },
+  { id: "copy", label: "Copy", emoji: "📋", style: ButtonStyle.Secondary },
+  { id: "no", label: "No", style: ButtonStyle.Danger },
+];
+
+/** Line above the copied link, naming what the bot did to it. */
+const COPY_LEAD = {
+  tracking: "Here's your link without the tracking junk:",
+  media: "Here's your embeddable link:",
+} as const;
+
+/**
+ * Hands the clicker their rewritten link privately, leaving their message
+ * untouched. A failure here is logged rather than thrown: the poster's message
+ * is already in the state they asked for.
+ * @param interaction - The "Copy" click, already acknowledged by the collector.
+ * @param link - The rewritten link to hand over.
+ * @param lead - Line shown above it, from {@link COPY_LEAD}.
+ * @returns A promise that resolves once the reply is sent or the failure logged.
+ */
+async function handOverLink(
+  interaction: ButtonInteraction | null,
+  link: string,
+  lead: string,
+): Promise<void> {
+  // followUp, not reply: the collector already acknowledged the click.
+  await interaction
+    ?.followUp({
+      content: buildCopyMessage(link, lead),
+      flags: MessageFlags.Ephemeral,
+    })
+    .catch((err: unknown) => {
+      log.warn("failed to hand over link", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}
 
 /**
  * Handles a message: detect media links, get approval, and repost/notify.
@@ -64,38 +109,35 @@ export async function handleMediaMessage(message: Message): Promise<void> {
   const plan = resolveApprovalPlan(settings.grace, sameChannel);
   if (isTrackingClean) plan.promptText = "Clean the tracking junk out of your link?";
 
-  // Auto-approve or ask. Tracking cleans offer a third option: hand the poster
-  // the cleaned link privately and leave their message untouched. They always
-  // prompt, since the same-channel plan never auto-approves.
+  // Auto-approve or ask. Every prompt offers a third option: hand the poster
+  // the rewritten link privately and leave their message untouched. Tracking
+  // cleans always prompt, since the same-channel plan never auto-approves.
   let approved = plan.autoApprove;
-  if (isTrackingClean) {
-    const { choice, interaction } = await requestChoice(source, message.author, CLEAN_BUTTONS, {
-      prompt: plan.promptText,
-      grace: plan.timeoutMs ?? 15_000,
-      autoDelete: true,
-    });
+  if (!approved) {
+    const { choice, interaction } = await requestChoice(
+      source,
+      message.author,
+      isTrackingClean ? CLEAN_BUTTONS : MEDIA_BUTTONS,
+      {
+        prompt: plan.promptText,
+        grace: plan.persistIndefinitely ? "disabled" : (plan.timeoutMs ?? 10_000),
+        autoDelete: !plan.persistIndefinitely,
+      },
+    );
     if (choice === "copy") {
-      // followUp, not reply: the collector already acknowledged the click.
-      await interaction
-        ?.followUp({
-          content: buildCopyMessage(rewrite.newLink),
-          flags: MessageFlags.Ephemeral,
-        })
-        .catch((err: unknown) => {
-          log.warn("failed to hand over cleaned link", {
-            error: err instanceof Error ? err.message : String(err),
-          });
-        });
-      log.info("poster copied cleaned link", { guildId: message.guildId!, from: source.id });
+      await handOverLink(
+        interaction,
+        rewrite.newLink,
+        isTrackingClean ? COPY_LEAD.tracking : COPY_LEAD.media,
+      );
+      log.info("poster copied link", {
+        guildId: message.guildId!,
+        from: source.id,
+        which: match.which,
+      });
       return;
     }
-    approved = choice === "repost";
-  } else if (!approved) {
-    approved = await requestApproval(source, message.author, {
-      prompt: plan.promptText,
-      grace: plan.persistIndefinitely ? "disabled" : (plan.timeoutMs ?? 10_000),
-      autoDelete: !plan.persistIndefinitely,
-    });
+    approved = choice === "yes";
   }
 
   log.debug("approval result", { approved, sameChannel, targetId });


### PR DESCRIPTION
The media prompt only ever offered Yes or No. Someone who just wanted the embeddable link - to paste
in another server, or send to one person - had to say Yes, let the bot delete and move the message,
then go into the media channel to fetch the link back out. The tracking-clean prompt has had a Copy
button for exactly this; the media one did not.

Both media prompts now carry it:

```
Move your media link to the media channel?           [Yes] [Copy] [No]
Rewrite your link here with an embeddable version?   [Yes] [Copy] [No]
```

Copy answers the poster privately with the rewritten link, fenced so Discord renders no embed and
mobile shows a copy button, and leaves their message exactly where it is - nothing moved, deleted,
or tailed. Same contract as the tracking-clean Copy, with its own lead line ("Here's your embeddable
link:").

- The `instant` grace setting shows no prompt at all, so there is no Copy on that path - only guilds
  with a grace window get the button.
- A failed hand-over is logged rather than thrown: the poster's message is already in the state they
  asked for.

The media path went through `requestApproval`, which returns a bare boolean and so cannot hand back
the click needed to answer the poster privately. Both paths now share one `requestChoice` call and
one hand-over helper, differing only in button set and lead line. That leaves `requestApproval` with
no callers, so it goes.

`buildCopyMessage` moves out of `cleanTracking.ts` into its own `copyLink.ts` and takes its lead
line as an argument. It fences a URL, which is not tracking logic, and a media-facing helper does
not belong in the file whose job is stripping tracking params.

## Over-broad tracking params dropped

`TRACKING_PARAMS` is meant to hold only keys that are unambiguously tracking, so a functional param
is never stripped out from under a link. Five entries did not meet that bar and are gone: `si`,
`spm`, `share_id`, `ref_src` and `ref_url` are all short or generic enough that a site can
legitimately mean something functional by them, and a wrong strip breaks a link rather than just
cleaning it.

`cmpid` and `s_cid` stay. They read generic but both spell out "campaign id", and nothing uses them
functionally.

The cost is YouTube share links, which carry their tracking in `si=`. YouTube is not a media-channel
platform, so the tracking prompt was the only thing catching them, and they now go unoffered. Worth
a follow-up if you want it back: scoping `si` to youtube.com/youtu.be gets the capability without
the generic-key risk.

## Also in here

- The readme described both prompts as Yes/No. The tracking one had been a three-button prompt for a
  while, so that line was already stale.

2.9.0 - the Copy button is a user-facing feature, and the param pruning is a fix on top of it.

## Verification

`npm run typecheck`, `npm run lint`, and `npm run smoke` (131 checks) all pass; the pre-commit and
pre-push hooks ran them again on the way out. Two smoke checks are new or tightened: the copy
hand-off now asserts the full lead-plus-fence shape rather than only that the fence appears
somewhere, and the dropped param keys are pinned as non-trackers so they cannot creep back. The
existing tracking check moves to `fbclid` with a functional param alongside it, which it should have
exercised anyway.
