### PR TITLE
Answer the Copy click with a reply instead of a followUp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ yarn-error.log*
 # responses.json (your own replies, plus the legacy slur_responses.json) stay
 # local; data/readme.md and the .example file document the shapes.
 !/data/global/responses.example.json
+docs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reactionbot",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reactionbot",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "dependencies": {
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2"
@@ -15,16 +15,16 @@
         "@eslint/js": "^10.0.1",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-jsdoc": "^63.3.2",
+        "eslint-plugin-jsdoc": "^63.3.3",
         "eslint-plugin-prettier": "^5.5.6",
-        "globals": "^17.8.0",
+        "globals": "^17.9.0",
         "lint-staged": "^17.3.0",
         "prettier": "^3.9.6",
         "prettier-plugin-organize-imports": "^4.3.0",
         "prettier-plugin-packagejson": "^3.0.2",
         "simple-git-hooks": "^2.13.1",
         "tsc-alias": "^1.9.1",
-        "tsx": "^4.23.1",
+        "tsx": "^4.23.5",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.65.0"
       },
@@ -1654,9 +1654,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.2.tgz",
-      "integrity": "sha512-5B3oO23iqbNJC/ru7uqIY80wmY66De1Q0+5kXQGHuLrGze/rL0Zw/YktMcqgYQ+kdHmgvY1q5TpRgl3yZMLmhQ==",
+      "version": "63.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.3.tgz",
+      "integrity": "sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2010,9 +2010,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2921,9 +2921,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactionbot",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "type": "module",
   "scripts": {
     "build": "node -e \"fs.rmSync('build',{recursive:true,force:true,maxRetries:10,retryDelay:200});fs.rmSync('tsconfig.tsbuildinfo',{force:true})\" && tsc && tsc-alias",
@@ -31,16 +31,16 @@
     "@eslint/js": "^10.0.1",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-jsdoc": "^63.3.2",
+    "eslint-plugin-jsdoc": "^63.3.3",
     "eslint-plugin-prettier": "^5.5.6",
-    "globals": "^17.8.0",
+    "globals": "^17.9.0",
     "lint-staged": "^17.3.0",
     "prettier": "^3.9.6",
     "prettier-plugin-organize-imports": "^4.3.0",
     "prettier-plugin-packagejson": "^3.0.2",
     "simple-git-hooks": "^2.13.1",
     "tsc-alias": "^1.9.1",
-    "tsx": "^4.23.1",
+    "tsx": "^4.23.5",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0"
   },

--- a/src/media/approval.ts
+++ b/src/media/approval.ts
@@ -12,6 +12,7 @@ import {
   ButtonStyle,
   ComponentType,
   GuildTextBasedChannel,
+  MessageFlags,
   User,
 } from "discord.js";
 
@@ -33,12 +34,28 @@ export interface ChoiceButton {
 export interface ChoiceOutcome {
   /** The clicked button's id, or null on timeout or send failure. */
   choice: string | null;
-  /**
-   * The click interaction, so callers can answer the clicker privately. Null
-   * when nothing was clicked. Already acknowledged by the collector, so use
-   * `followUp` rather than `reply`.
-   */
-  interaction: ButtonInteraction | null;
+}
+
+/**
+ * Acknowledges a click: a private reply when the button has one to give, else
+ * clears the prompt's buttons. Replies rather than updates - `update` makes the
+ * prompt this interaction's original response, which the cleanup then deletes,
+ * dropping any later `followUp` against it.
+ * @param i - The click to acknowledge.
+ * @param [privateReply] - Ephemeral text for this button, if it has any.
+ * @returns A promise that resolves once the response is sent or logged.
+ */
+async function answerClick(i: ButtonInteraction, privateReply?: string): Promise<void> {
+  if (privateReply === undefined) {
+    await i.update({ components: [] }).catch(() => {});
+    return;
+  }
+  await i.reply({ content: privateReply, flags: MessageFlags.Ephemeral }).catch((err: unknown) => {
+    log.warn("failed to answer click privately", {
+      choice: i.customId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
 }
 
 /**
@@ -46,6 +63,7 @@ export interface ChoiceOutcome {
  * - Only `author` clicks are accepted; everyone else's are ignored.
  * - `grace: "instant"` resolves to `opts.instantChoice` without showing UI.
  *   `"disabled"` waits indefinitely.
+ * - A button in `opts.privateReplies` answers the clicker ephemerally.
  * - On end: deletes the prompt if `autoDelete` and `grace !== "disabled"`,
  *   else strips the buttons so it cannot be clicked later.
  * @param channel - Target channel for the prompt.
@@ -53,7 +71,7 @@ export interface ChoiceOutcome {
  * @param buttons - The choices to offer, in display order.
  * @param [opts] - Prompt and behaviour controls.
  * @param [opts.instantChoice] - Choice returned when `grace` is `"instant"`.
- * @returns The chosen button id and the click interaction.
+ * @returns The chosen button id.
  */
 export async function requestChoice(
   channel: GuildTextBasedChannel,
@@ -68,7 +86,7 @@ export async function requestChoice(
   // Instant path: resolve without showing UI
   if (grace === "instant") {
     log.debug("instant choice", { channelId: channel.id, userId: author.id });
-    return { choice: opts.instantChoice ?? null, interaction: null };
+    return { choice: opts.instantChoice ?? null };
   }
 
   const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -91,7 +109,7 @@ export async function requestChoice(
       channelId: channel.id,
       userId: author.id,
     });
-    return { choice: null, interaction: null };
+    return { choice: null };
   }
 
   // Collector config
@@ -104,7 +122,9 @@ export async function requestChoice(
 
   const ids = new Set(buttons.map((b) => b.id));
   let choice: string | null = null;
-  let clicked: ButtonInteraction | null = null;
+  // "end" fires without waiting on "collect", so cleanup would race the click's
+  // response. Park it here for "end" to await.
+  let answered: Promise<void> = Promise.resolve();
 
   const collector = msg.createMessageComponentCollector({
     componentType: ComponentType.Button,
@@ -113,15 +133,15 @@ export async function requestChoice(
     filter: (i: ButtonInteraction) => i.user.id === author.id && ids.has(i.customId),
   });
 
-  collector.on("collect", async (i: ButtonInteraction) => {
+  collector.on("collect", (i: ButtonInteraction) => {
     choice = i.customId;
-    clicked = i;
     log.debug("choice click", { userId: i.user.id, choice: i.customId });
-    await i.update({ components: [] }).catch(() => {});
+    answered = answerClick(i, opts.privateReplies?.[i.customId]);
   });
 
   return new Promise((resolve) => {
     collector.on("end", async () => {
+      await answered;
       if (autoDelete && grace !== "disabled") {
         await msg.delete().catch(() => {});
         log.debug("prompt deleted", { messageId: msg.id });
@@ -130,7 +150,7 @@ export async function requestChoice(
         await msg.edit({ components: [] }).catch(() => {});
         log.debug("prompt buttons cleared", { messageId: msg.id });
       }
-      resolve({ choice, interaction: clicked });
+      resolve({ choice });
     });
   });
 }

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -96,4 +96,10 @@ export interface ApprovalOptions {
    * Default: `true` unless `grace === "disabled"`, in which case the message is left visible.
    */
   autoDelete?: boolean;
+
+  /**
+   * Ephemeral text answering a click, keyed by button id. Listed buttons reply
+   * privately instead of editing the prompt, so the reply survives `autoDelete`.
+   */
+  privateReplies?: Record<string, string>;
 }

--- a/src/media/workflow.ts
+++ b/src/media/workflow.ts
@@ -11,13 +11,7 @@ import { registerRepostActions } from "@/media/repostActions";
 import { loadSettings, resolveApprovalPlan, resolveTargetChannelId } from "@/media/settings";
 import { rewriteContent } from "@/media/transform";
 import { createLogger } from "@/utils/log";
-import {
-  ButtonInteraction,
-  ButtonStyle,
-  GuildTextBasedChannel,
-  Message,
-  MessageFlags,
-} from "discord.js";
+import { ButtonStyle, GuildTextBasedChannel, Message } from "discord.js";
 
 const log = createLogger("media/workflow");
 
@@ -43,33 +37,6 @@ const COPY_LEAD = {
   tracking: "Here's your link without the tracking junk:",
   media: "Here's your embeddable link:",
 } as const;
-
-/**
- * Hands the clicker their rewritten link privately, leaving their message
- * untouched. A failure here is logged rather than thrown: the poster's message
- * is already in the state they asked for.
- * @param interaction - The "Copy" click, already acknowledged by the collector.
- * @param link - The rewritten link to hand over.
- * @param lead - Line shown above it, from {@link COPY_LEAD}.
- * @returns A promise that resolves once the reply is sent or the failure logged.
- */
-async function handOverLink(
-  interaction: ButtonInteraction | null,
-  link: string,
-  lead: string,
-): Promise<void> {
-  // followUp, not reply: the collector already acknowledged the click.
-  await interaction
-    ?.followUp({
-      content: buildCopyMessage(link, lead),
-      flags: MessageFlags.Ephemeral,
-    })
-    .catch((err: unknown) => {
-      log.warn("failed to hand over link", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
-}
 
 /**
  * Handles a message: detect media links, get approval, and repost/notify.
@@ -114,7 +81,7 @@ export async function handleMediaMessage(message: Message): Promise<void> {
   // cleans always prompt, since the same-channel plan never auto-approves.
   let approved = plan.autoApprove;
   if (!approved) {
-    const { choice, interaction } = await requestChoice(
+    const { choice } = await requestChoice(
       source,
       message.author,
       isTrackingClean ? CLEAN_BUTTONS : MEDIA_BUTTONS,
@@ -122,14 +89,15 @@ export async function handleMediaMessage(message: Message): Promise<void> {
         prompt: plan.promptText,
         grace: plan.persistIndefinitely ? "disabled" : (plan.timeoutMs ?? 10_000),
         autoDelete: !plan.persistIndefinitely,
+        privateReplies: {
+          copy: buildCopyMessage(
+            rewrite.newLink,
+            isTrackingClean ? COPY_LEAD.tracking : COPY_LEAD.media,
+          ),
+        },
       },
     );
     if (choice === "copy") {
-      await handOverLink(
-        interaction,
-        rewrite.newLink,
-        isTrackingClean ? COPY_LEAD.tracking : COPY_LEAD.media,
-      );
       log.info("poster copied link", {
         guildId: message.guildId!,
         from: source.id,


### PR DESCRIPTION
The Copy button did nothing on mobile: no clipboard, and no ephemeral message either.

## Cause

`requestChoice` acknowledged every click with `update()`, which makes the prompt that interaction's original response. The collector's `end` handler then deleted that prompt, and the workflow only afterwards called `followUp()` against it. A `followUp` against a deleted original response is dropped, and the failure was swallowed into a `log.warn`, so the clicker saw nothing at all.

`end` also fires as soon as `max` is hit, without waiting on the async `collect` listener, so the delete was racing the response as well.

## Fix

- New `privateReplies` option on `ApprovalOptions`, keyed by button id. A button listed there answers with its own first `reply()`, which leaves the prompt an ordinary message that cleanup is free to remove.
- `end` awaits the in-flight response before deleting the prompt.
- `ChoiceOutcome` loses its `interaction` field. It existed only to enable the `followUp` that caused this, and workflow.ts was its only consumer.

Note this makes the ephemeral message appear reliably. It does not put anything on the clipboard: Discord has no clipboard action for bots, so the actual copy is still the tap on Discord's own icon on the fenced code block.

## Also

`docs/` is now gitignored. Specs there are working notes rather than something the bot ships.

Patch bump to 2.9.1. Verified with `npm run typecheck`, `npm run lint`, `npm run build` and all 131 smoke checks.
