### PR TITLE
Let members set how their own links get moved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,21 +12,21 @@
         "dotenv": "^17.4.2"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
-        "eslint": "^10.8.0",
+        "@eslint/js": "^9.39.5",
+        "eslint": "^9.39.5",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-jsdoc": "^63.3.3",
+        "eslint-plugin-jsdoc": "^64.2.1",
         "eslint-plugin-prettier": "^5.5.6",
-        "globals": "^17.9.0",
+        "globals": "^17.11.0",
         "lint-staged": "^17.3.0",
         "prettier": "^3.9.6",
         "prettier-plugin-organize-imports": "^4.3.0",
         "prettier-plugin-packagejson": "^3.0.2",
         "simple-git-hooks": "^2.13.1",
-        "tsc-alias": "^1.9.1",
-        "tsx": "^4.23.5",
+        "tsc-alias": "^1.9.2",
+        "tsx": "^4.23.12",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.65.0"
+        "typescript-eslint": "^8.67.0"
       },
       "engines": {
         "node": "24.x",
@@ -164,20 +164,20 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.91.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.91.0.tgz",
-      "integrity": "sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==",
+      "version": "0.95.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.95.1.tgz",
+      "integrity": "sha512-LO/RI08Fo9bhXwB7Od9G+1j3eSNq63+ZS5CQO8YLXHbDg6kx6S/DhTeY0+Fc9uZrjK1zZSyTx8Sg5gv5DIoCnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.9",
-        "@typescript-eslint/types": "^8.65.0",
-        "comment-parser": "1.4.7",
+        "@typescript-eslint/types": "^8.67.0",
+        "comment-parser": "1.4.8",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~8.0.0"
+        "jsdoc-type-pratt-parser": "~9.1.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^22.22.2 || >=24.15.0"
       }
     },
     "node_modules/@es-joy/resolve.exports": {
@@ -675,89 +675,149 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
-      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -923,13 +983,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -963,17 +1016,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/type-utils": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -986,7 +1039,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1002,16 +1055,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1027,14 +1080,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.65.0",
-        "@typescript-eslint/types": "^8.65.0",
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1049,14 +1102,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0"
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1067,9 +1120,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1084,15 +1137,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1109,9 +1162,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1123,16 +1176,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.65.0",
-        "@typescript-eslint/tsconfig-utils": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1150,17 +1203,56 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0"
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1175,13 +1267,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/types": "8.67.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1242,6 +1334,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -1270,14 +1378,21 @@
       }
     },
     "node_modules/are-docs-informative": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
-      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.1.1.tgz",
+      "integrity": "sha512-sqRsNQBwbKLRX0jV5Cu5uzmtflf892n4Vukz7T659ebL4pz3mpOqCMU7lxMoBTFwnp10E3YB5ZcyHM41W5bcDA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -1290,14 +1405,11 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1313,16 +1425,14 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -1336,6 +1446,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -1376,6 +1513,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -1387,14 +1544,21 @@
       }
     },
     "node_modules/comment-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
-      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.8.tgz",
+      "integrity": "sha512-rKZTGo4fzKYna8UcL0isTg5wkBNla7bxTypLwZQXjIdi++IdP1OJ41rI5Mti3/jltkPujbu4i9LIARYA+zpotQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1579,33 +1743,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
-      "workspaces": [
-        "packages/*"
-      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.7.0",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -1615,7 +1779,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.5",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1623,7 +1788,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -1654,18 +1819,18 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.3.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.3.tgz",
-      "integrity": "sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==",
+      "version": "64.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-64.2.1.tgz",
+      "integrity": "sha512-6GpSYxLPcbMw38S94Cngrgs1Zv8yLinQS1O17OxJVZ6deLbrMRCERUYQKceweSqEuG2kx5Amn4l3aKPkCp4geQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.91.0",
+        "@es-joy/jsdoccomment": "~0.95.1",
         "@es-joy/resolve.exports": "1.2.0",
-        "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.7",
+        "are-docs-informative": "^0.1.1",
+        "comment-parser": "1.4.8",
         "debug": "^4.4.3",
-        "escape-string-regexp": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
         "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "html-entities": "^2.6.0",
@@ -1676,10 +1841,23 @@
         "to-valid-identifier": "^1.0.0"
       },
       "engines": {
-        "node": "^22.13.0 || >=24"
+        "node": "^22.22.2 || >=24.15.0"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -1714,19 +1892,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1740,6 +1916,37 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2010,9 +2217,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2043,6 +2250,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -2068,6 +2285,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -2146,14 +2380,40 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
-      "integrity": "sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-9.1.2.tgz",
+      "integrity": "sha512-9EXymowgk1mb9RY1VxuwKc+AhaxfBk2CV0dWxgGM+l5RURTtiUoAx7MlKwcsiVcEXK5HEPa7FeH/tsRpqjEPRg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9"
+      },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^22.22.2 || >=24.15.0"
       }
     },
     "node_modules/json-buffer": {
@@ -2247,6 +2507,13 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
@@ -2297,19 +2564,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.8"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -2405,6 +2669,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/parse-imports-exports": {
@@ -2634,6 +2911,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -2800,6 +3087,32 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
@@ -2893,9 +3206,9 @@
       "license": "MIT"
     },
     "node_modules/tsc-alias": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.9.1.tgz",
-      "integrity": "sha512-sFZdVFthH8uvdplPJrOYGOHcxu6UPtcAcY678JPwEQiMzgLZYFO7Qc/rzELp7ingTc+OxtzH6n+8Pn2eVQep6w==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.9.2.tgz",
+      "integrity": "sha512-VTWQGMv0xXCEyHDLpmV2DEvGYHMxwsyx87dZeou2ynkM0+WOFdHe+KWiRucavMPUEdQysr7xSu60Y/WY0R4YKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2921,9 +3234,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.5",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
-      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2967,16 +3280,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
-      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.65.0",
-        "@typescript-eslint/parser": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0"
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reactionbot",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reactionbot",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "dependencies": {
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2"

--- a/package.json
+++ b/package.json
@@ -28,21 +28,21 @@
     "dotenv": "^17.4.2"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
-    "eslint": "^10.8.0",
+    "@eslint/js": "^9.39.5",
+    "eslint": "^9.39.5",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-jsdoc": "^63.3.3",
+    "eslint-plugin-jsdoc": "^64.2.1",
     "eslint-plugin-prettier": "^5.5.6",
-    "globals": "^17.9.0",
+    "globals": "^17.11.0",
     "lint-staged": "^17.3.0",
     "prettier": "^3.9.6",
     "prettier-plugin-organize-imports": "^4.3.0",
     "prettier-plugin-packagejson": "^3.0.2",
     "simple-git-hooks": "^2.13.1",
-    "tsc-alias": "^1.9.1",
-    "tsx": "^4.23.5",
+    "tsc-alias": "^1.9.2",
+    "tsx": "^4.23.12",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.65.0"
+    "typescript-eslint": "^8.67.0"
   },
   "engines": {
     "node": "24.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactionbot",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "type": "module",
   "scripts": {
     "build": "node -e \"fs.rmSync('build',{recursive:true,force:true,maxRetries:10,retryDelay:200});fs.rmSync('tsconfig.tsbuildinfo',{force:true})\" && tsc && tsc-alias",

--- a/readme.md
+++ b/readme.md
@@ -9,14 +9,15 @@ per-server counters for swears, slurs, and name-calling.
 ## Features
 
 - **Media link relocation**: detect link > Yes/Copy/No prompt for the author (configurable grace,
-  including instant auto-move) > delete the original > repost the rewritten link in the media
-  channel > leave a pointer "tail" in the source channel. **Copy** is the quiet way out: the author
-  gets the embeddable link privately and their message is left exactly where it is. The full message
-  text and any attachments are carried over, and anyone the message tagged is named on the tail too
-  ("SENT SLOP TO ...") - mentions render without pinging. The author can change a moved post by
-  right-clicking it - or its tail - and picking **Apps > Edit post** (a popup pre-filled with the
-  text) or **Apps > Delete post** (removes the post and its tail together). Records are persisted,
-  so both keep working after bot restarts. Links edited into an existing message are caught too.
+  including instant auto-move, and per-member overrides via `/mydelay`) > delete the original >
+  repost the rewritten link in the media channel > leave a pointer "tail" in the source channel.
+  **Copy** is the quiet way out: the author gets the embeddable link privately and their message is
+  left exactly where it is. The full message text and any attachments are carried over, and anyone
+  the message tagged is named on the tail too ("SENT SLOP TO ...") - mentions render without
+  pinging. The author can change a moved post by right-clicking it - or its tail - and picking
+  **Apps > Edit post** (a popup pre-filled with the text) or **Apps > Delete post** (removes the
+  post and its tail together). Records are persisted, so both keep working after bot restarts. Links
+  edited into an existing message are caught too.
 - **Embed-friendly rewrites**: URLs are swapped to frontends that actually embed in Discord (see
   `FRONTENDS` in [src/media/transform.ts](src/media/transform.ts)).
 - **Pre-fixed links move too**: links already on a fixer frontend (fxtwitter, cunnyx, ddinstagram,
@@ -70,16 +71,35 @@ deploy.
 Admin commands (settings and the nukes) require the bot owner (the `YOUR_ID` env var), the guild
 owner, or the Manage Server permission. Everything else works for anyone, in any channel.
 
+`/setdelay`, `/setmediachannel`, and `/calmdown` are registered with Manage Server as their default
+permission, so Discord keeps them out of the slash-command picker for everyone else and `/help`
+leaves them out to match. It is a default, not a lock - a server admin can grant them per role,
+member, or channel under Server Settings > Integrations, and the runtime check still applies either
+way. Two consequences worth knowing: the `YOUR_ID` owner grant cannot beat the picker, so in a
+server where the bot owner holds neither ownership nor Manage Server those commands are out of
+reach; and Discord filters per command rather than per subcommand, so commands that mix open and
+admin subcommands (`/slurs nuke`, `/swears nuke`) stay visible to everyone and are marked 🔒 in
+`/help` instead.
+
 - `/setmediachannel` - set which text channel media links get reposted into.
 - `/setdelay instant` - move links straight away without asking.
 - `/setdelay seconds seconds:<1-300>` - give the poster that long to hit Yes or No.
 - `/setdelay disabled` - always ask, and wait forever for an answer.
+- `/setdelay personal [enabled] [max-seconds] [allow-never]` - what members may set for themselves
+  with `/mydelay`. Every option is optional; only the ones you supply change. Defaults to on, up to
+  300s, opt-out allowed.
+- `/mydelay instant|countdown|ask|never|show|clear` - anyone, for their own links only. `instant`
+  moves yours straight away; `countdown seconds:<1-300>` moves yours when the timer runs out unless
+  you hit Cancel; `ask seconds:<1-300>` is the usual Yes/Copy/No prompt; `never` leaves yours alone
+  without prompting; `show` reports what is actually in force (admin bounds are applied when the
+  setting is read, so it is not always what you typed); `clear` drops yours. Governs moves to the
+  media channel only - same-channel rewrites and tracking cleans still ask.
 - `/calmdown start [minutes]`, `/calmdown stop` - pause the configured GIF/text replies (default 30
   minutes); reactions and counting keep going. Also kicks in automatically after a spam-escalation
   reply fires (5 hits in 30s across all users, sent once per episode), so a flood gets one "enough"
   and then quiet for 5 minutes or 20 messages, whichever comes first - tune per server with
   `/calmdown auto [minutes] [messages]`.
-- `/help` - list all commands.
+- `/help` - list the commands you can run, with 🔒 on admin-only subcommands.
 
 ### Right-click a moved post
 

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -6,16 +6,26 @@
 //
 //   npx tsx scripts/smoke-test.ts [--verbose]   # --verbose echoes every check
 
+import { data as calmDown } from "@/commands/calmdown";
 import { data as deletePost } from "@/commands/deletepost";
 import { data as editPost } from "@/commands/editpost";
-import { resolveGrace } from "@/commands/setdelay";
+import { buildHelpFields } from "@/commands/help";
+import { data as myDelay, resolvePref } from "@/commands/mydelay";
+import { mergePersonal, resolveGrace, data as setDelay } from "@/commands/setdelay";
+import { data as setMediaChannel } from "@/commands/setmediachannel";
 import { data as slursCommand } from "@/commands/slurs";
+import { data as swearsCommand } from "@/commands/swears";
+import { isApproved } from "@/media/approval";
 import { stripTracking } from "@/media/cleanTracking";
 import { buildCopyMessage } from "@/media/copyLink";
 import { matchAny } from "@/media/match";
+import { clampPref, clearPref, loadPref, savePref } from "@/media/prefs";
 import { buildMovedContent, buildPointerContent, collectMentions } from "@/media/repost";
 import { findRepostForMessage, getRepost, removeRepost, saveRepost } from "@/media/repostStore";
+import { resolvePlanFor } from "@/media/settings";
 import { buildTransformedUrl, rewriteContent } from "@/media/transform";
+import { MediaSettings } from "@/media/types";
+import { copyHintFor } from "@/media/workflow";
 import { trackerCommand } from "@/tracking/commands";
 import { aggregateByCategory, countMatches, wordToPattern } from "@/tracking/detect";
 import {
@@ -40,7 +50,8 @@ import { phraseToEmojis, resolveReactions } from "@/tracking/track";
 import { SLURS, SWEARS } from "@/tracking/trackers";
 import { loadWords, parseJsonc } from "@/tracking/words";
 import { recordReply, takeReplies } from "@/utils/replyStore";
-import { ApplicationCommandType } from "discord-api-types/v10";
+import { ApplicationCommandOptionType, ApplicationCommandType } from "discord-api-types/v10";
+import { PermissionFlagsBits } from "discord.js";
 import { mkdirSync, readdirSync, rmSync, writeFileSync } from "fs";
 import path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
@@ -835,6 +846,240 @@ function checkGifs(): void {
   );
 }
 
+/**
+ * Verifies per-member move preferences: how a stored choice resolves into an
+ * approval plan, how admin bounds clamp it on read, how silence is read under
+ * each mode, and that the store round-trips. Cross-channel moves only - the
+ * same-channel rewrite must ignore preferences entirely.
+ */
+function checkMemberPrefs(): void {
+  const guild = "__smoketest__";
+  const guildDefault: MediaSettings = { grace: 10_000 };
+
+  check(
+    "prefs",
+    "no stored preference leaves the guild default",
+    resolvePlanFor(guildDefault, undefined, false)?.timeoutMs === 10_000,
+  );
+  check(
+    "prefs",
+    "instant moves without prompting",
+    resolvePlanFor({ grace: "disabled" }, { mode: "instant" }, false)?.autoApprove === true,
+  );
+
+  const countdown = resolvePlanFor(guildDefault, { mode: "countdown", seconds: 30 }, false);
+  check(
+    "prefs",
+    "countdown counts silence as approval",
+    countdown?.autoApprove === false &&
+      countdown.approveOnTimeout === true &&
+      countdown.timeoutMs === 30_000,
+  );
+
+  const ask = resolvePlanFor(guildDefault, { mode: "ask", seconds: 15 }, false);
+  check(
+    "prefs",
+    "ask needs a click and never approves on timeout",
+    ask?.autoApprove === false && ask.approveOnTimeout === false && ask.timeoutMs === 15_000,
+  );
+
+  check(
+    "prefs",
+    "never skips the move entirely",
+    resolvePlanFor(guildDefault, { mode: "never" }, false) === null,
+  );
+
+  // Bounds are applied on read, so tightening them reaches preferences that
+  // were already saved under the looser limit.
+  check(
+    "prefs",
+    "seconds clamp to the admin maximum on read",
+    resolvePlanFor(
+      { grace: 10_000, personal: { enabled: true, maxSeconds: 60, allowNever: true } },
+      { mode: "countdown", seconds: 300 },
+      false,
+    )?.timeoutMs === 60_000,
+  );
+  check(
+    "prefs",
+    "never falls back to the guild default when it is not allowed",
+    resolvePlanFor(
+      { grace: 10_000, personal: { enabled: true, maxSeconds: 300, allowNever: false } },
+      { mode: "never" },
+      false,
+    )?.timeoutMs === 10_000,
+  );
+  check(
+    "prefs",
+    "personal preferences switched off ignores a stored preference",
+    resolvePlanFor(
+      { grace: 10_000, personal: { enabled: false, maxSeconds: 300, allowNever: true } },
+      { mode: "instant" },
+      false,
+    )?.autoApprove === false,
+  );
+  check(
+    "prefs",
+    "same-channel rewrites ignore member preferences",
+    resolvePlanFor(guildDefault, { mode: "instant" }, true)?.timeoutMs === 15_000,
+  );
+
+  // What /mydelay show reports: the preference after clamping, not the one
+  // that was typed.
+  check(
+    "prefs",
+    "clamping reports what is actually active",
+    clampPref({ mode: "ask", seconds: 300 }, { enabled: true, maxSeconds: 20, allowNever: true })
+      ?.seconds === 20 &&
+      clampPref({ mode: "never" }, { enabled: true, maxSeconds: 20, allowNever: false }) ===
+        undefined,
+  );
+
+  // A prompt that never reached the channel must not read as silent consent,
+  // or a failed send would move the link on its own.
+  const cd = resolvePlanFor(guildDefault, { mode: "countdown", seconds: 30 }, false)!;
+  check(
+    "prefs",
+    "countdown treats an unsent prompt as leave it",
+    isApproved(cd, { choice: null, prompted: false }) === false,
+  );
+  check(
+    "prefs",
+    "countdown moves when nobody cancels",
+    isApproved(cd, { choice: null, prompted: true }) === true,
+  );
+  check(
+    "prefs",
+    "countdown stops on cancel",
+    isApproved(cd, { choice: "no", prompted: true }) === false,
+  );
+  const asked = resolvePlanFor(guildDefault, { mode: "ask", seconds: 15 }, false)!;
+  check(
+    "prefs",
+    "ask approves only on yes",
+    isApproved(asked, { choice: null, prompted: true }) === false &&
+      isApproved(asked, { choice: "yes", prompted: true }) === true,
+  );
+
+  try {
+    savePref(guild, "u1", { mode: "countdown", seconds: 45 });
+    const loaded = loadPref(guild, "u1");
+    check(
+      "prefs",
+      "store round-trips a member preference",
+      loaded?.mode === "countdown" && loaded.seconds === 45,
+    );
+    clearPref(guild, "u1");
+    check("prefs", "store clears a member preference", loadPref(guild, "u1") === undefined);
+  } finally {
+    rmSync(path.join(ROOT, "data", guild), { recursive: true, force: true });
+  }
+
+  check(
+    "prefs",
+    "the copy hand-off carries a hint under the fenced link",
+    buildCopyMessage("https://example.com/x", "Here you go:", "-# hint").endsWith("```\n-# hint"),
+  );
+
+  check(
+    "prefs",
+    "a countdown choice keeps its seconds, instant carries none",
+    resolvePref("countdown", 45).seconds === 45 && resolvePref("instant").seconds === undefined,
+  );
+
+  // Every /setdelay personal option is optional, so an admin can tighten one
+  // bound without restating the others.
+  check(
+    "prefs",
+    "personal bounds change only what was supplied",
+    JSON.stringify(
+      mergePersonal(
+        { enabled: true, maxSeconds: 300, allowNever: true },
+        { enabled: null, maxSeconds: 60, allowNever: null },
+      ),
+    ) === JSON.stringify({ enabled: true, maxSeconds: 60, allowNever: true }),
+  );
+
+  // The hint promises control that /mydelay only has over cross-channel moves.
+  check(
+    "prefs",
+    "the /mydelay hint rides on cross-channel moves only",
+    copyHintFor(false, false)?.includes("/mydelay") === true &&
+      copyHintFor(true, false) === undefined &&
+      copyHintFor(false, true) === undefined,
+  );
+
+  const mine = myDelay.toJSON();
+  const subs = (mine.options ?? [])
+    .filter((o) => o.type === ApplicationCommandOptionType.Subcommand)
+    .map((o) => o.name);
+  check(
+    "prefs",
+    "/mydelay registers its subcommands",
+    mine.name === "mydelay" &&
+      ["instant", "countdown", "ask", "never", "show", "clear"].every((n) => subs.includes(n)),
+  );
+  check(
+    "prefs",
+    "/setdelay gains a personal subcommand",
+    (setDelay.toJSON().options ?? []).some(
+      (o) => o.type === ApplicationCommandOptionType.Subcommand && o.name === "personal",
+    ),
+  );
+}
+
+/**
+ * Verifies who sees what. Discord filters the slash-command picker on a
+ * command's default permissions, so the fully-admin commands carry Manage
+ * Server and the mixed ones (open leaderboards, admin nuke) must not - the
+ * filter is per command, not per subcommand. /help then has to agree with the
+ * picker, or it advertises commands a member cannot reach.
+ */
+function checkCommandVisibility(): void {
+  const manageGuild = String(PermissionFlagsBits.ManageGuild);
+  for (const [label, builder] of [
+    ["/setdelay", setDelay],
+    ["/setmediachannel", setMediaChannel],
+    ["/calmdown", calmDown],
+  ] as const) {
+    check(
+      "perms",
+      `${label} is hidden from members without Manage Server`,
+      builder.toJSON().default_member_permissions === manageGuild,
+    );
+  }
+  for (const [label, builder] of [
+    ["/mydelay", myDelay],
+    ["/swears", swearsCommand],
+    ["/slurs", slursCommand],
+  ] as const) {
+    const perms = builder.toJSON().default_member_permissions;
+    check("perms", `${label} stays in everyone's picker`, perms === null || perms === undefined);
+  }
+
+  const asMember = buildHelpFields([setDelay.toJSON(), myDelay.toJSON()], false);
+  const asAdmin = buildHelpFields([setDelay.toJSON(), myDelay.toJSON()], true);
+  check(
+    "perms",
+    "/help hides what the picker hides",
+    !asMember.some((f) => f.name === "/setdelay") && asMember.some((f) => f.name === "/mydelay"),
+  );
+  check(
+    "perms",
+    "/help still lists admin commands for an admin",
+    asAdmin.some((f) => f.name === "/setdelay"),
+  );
+
+  // A command the picker cannot filter has to say so line by line.
+  const swears = buildHelpFields([swearsCommand.toJSON()], false)[0].value.split(/\r?\n/);
+  check(
+    "perms",
+    "/help marks the admin subcommand of a shared command",
+    swears.some((line) => line.includes("nuke") && line.includes("🔒")) &&
+      swears.some((line) => line.includes("top") && !line.includes("🔒")),
+  );
+}
+
 /* --------------------------------------------------------------- reporting */
 
 /**
@@ -859,11 +1104,13 @@ void (async () => {
 
   try {
     await checkCommandsLoad();
+    checkCommandVisibility();
     checkLinkTransforms();
     checkRepostContent();
     checkRepostStore();
     checkReactions();
     checkGrace();
+    checkMemberPrefs();
     checkSwears();
     checkTrackers();
     checkSlurResponses();

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -12,5 +12,7 @@
     "rootDir": "..",
     "noEmit": true
   },
-  "include": ["**/*.ts"]
+  // The ambient Client.commands declaration lives in src; without it the
+  // smoke test cannot see the command collection help.ts reads.
+  "include": ["**/*.ts", "../src/types/discord.d.ts"]
 }

--- a/src/commands/calmdown.ts
+++ b/src/commands/calmdown.ts
@@ -12,7 +12,7 @@ import { createLogger } from "@/utils/log";
 import { requireAdmin } from "@/utils/permissions";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { InteractionContextType } from "discord-api-types/v10";
-import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { ChatInputCommandInteraction, MessageFlags, PermissionFlagsBits } from "discord.js";
 
 const log = createLogger("cmd/calmdown");
 
@@ -52,6 +52,7 @@ export const data = new SlashCommandBuilder()
           .setMaxValue(1000),
       ),
   )
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
   .setContexts(InteractionContextType.Guild);
 
 /**

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,12 +1,18 @@
 // src/commands/help.ts
 
+import { ADMIN_SUBCOMMANDS, isAdmin } from "@/utils/permissions";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import {
+  APIEmbedField,
   ApplicationCommandOptionType,
   ApplicationCommandType,
   InteractionContextType,
+  RESTPostAPIApplicationCommandsJSONBody,
 } from "discord-api-types/v10";
 import { ChatInputCommandInteraction, EmbedBuilder, MessageFlags } from "discord.js";
+
+/** Marks a line that needs admin, for commands Discord cannot filter. */
+const ADMIN_MARK = "🔒";
 
 /** Slash command definition for `/help`. */
 export const data = new SlashCommandBuilder()
@@ -15,37 +21,67 @@ export const data = new SlashCommandBuilder()
   .setContexts(InteractionContextType.Guild);
 
 /**
- * Executes `/help`: an embed listing every loaded command with its
- * description, built from the live command collection. Commands with
- * subcommands list each subcommand with its own description.
- * @param interaction - The command interaction context.
- * @returns A promise that resolves when the reply is sent.
+ * Builds the embed fields listing commands. Commands carrying default
+ * permissions are the ones Discord keeps out of a member's picker, so they are
+ * left out here too for anyone who cannot run them - otherwise `/help`
+ * advertises commands that are not there to be found. Commands that mix open
+ * and admin subcommands stay listed, with the admin ones marked.
+ * @param commands - The loaded commands, as Discord registered them.
+ * @param admin - Whether the invoker may run admin commands.
+ * @returns One field per command the invoker can see.
  */
-export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
-  const embed = new EmbedBuilder().setTitle("Commands").setColor(0x5865f2);
-  const commands = [...interaction.client.commands.values()].sort((a, b) =>
-    a.data.name.localeCompare(b.data.name),
-  );
-  for (const cmd of commands) {
-    const json = cmd.data.toJSON();
+export function buildHelpFields(
+  commands: RESTPostAPIApplicationCommandsJSONBody[],
+  admin: boolean,
+): APIEmbedField[] {
+  const fields: APIEmbedField[] = [];
+  for (const json of commands) {
+    if (json.default_member_permissions && !admin) continue;
+
     // Right-click entries carry no description - Discord rejects one - and an
     // empty field value would be rejected too, so they get a fixed line saying
     // how to reach them instead.
     if (json.type === ApplicationCommandType.Message) {
-      embed.addFields({
+      fields.push({
         name: json.name,
         value: `Right-click a moved post or its pointer > Apps > \`${json.name}\``,
         inline: false,
       });
       continue;
     }
+
+    const adminSubs = ADMIN_SUBCOMMANDS[json.name] ?? [];
     const subs = ("options" in json ? (json.options ?? []) : []).filter(
       (o) => o.type === ApplicationCommandOptionType.Subcommand,
     );
     const value = subs.length
-      ? subs.map((s) => `\`/${json.name} ${s.name}\` - ${s.description}`).join("\n")
+      ? subs
+          .map((s) => {
+            const mark = adminSubs.includes(s.name) ? ` ${ADMIN_MARK}` : "";
+            return `\`/${json.name} ${s.name}\`${mark} - ${s.description}`;
+          })
+          .join("\n")
       : ("description" in json ? json.description : "") || "-";
-    embed.addFields({ name: `/${json.name}`, value, inline: false });
+    fields.push({ name: `/${json.name}`, value, inline: false });
+  }
+  return fields;
+}
+
+/**
+ * Executes `/help`: an embed listing every command the invoker can actually
+ * run, built from the live command collection.
+ * @param interaction - The command interaction context.
+ * @returns A promise that resolves when the reply is sent.
+ */
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  const commands = [...interaction.client.commands.values()]
+    .map((cmd) => cmd.data.toJSON())
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const fields = buildHelpFields(commands, isAdmin(interaction));
+
+  const embed = new EmbedBuilder().setTitle("Commands").setColor(0x5865f2).addFields(fields);
+  if (fields.some((f) => f.value.includes(ADMIN_MARK))) {
+    embed.setFooter({ text: `${ADMIN_MARK} needs Manage Server` });
   }
   await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
 }

--- a/src/commands/mydelay.ts
+++ b/src/commands/mydelay.ts
@@ -1,0 +1,228 @@
+// src/commands/mydelay.ts
+
+import { clampPref, clearPref, loadPref, resolveLimits, savePref } from "@/media/prefs";
+import { loadSettings } from "@/media/settings";
+import { GraceSetting, MemberMode, MemberPref, PersonalLimits } from "@/media/types";
+import { createLogger } from "@/utils/log";
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { InteractionContextType } from "discord-api-types/v10";
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+
+const log = createLogger("cmd/mydelay");
+
+/**
+ * Slash command definition for `/mydelay`. Governs cross-channel moves of the
+ * invoker's own links only; same-channel rewrites and tracking cleans keep
+ * asking regardless of what is set here.
+ */
+export const data = new SlashCommandBuilder()
+  .setName("mydelay")
+  .setDescription("⏱️ How your own media links get handled")
+  .addSubcommand((sub) =>
+    sub.setName("instant").setDescription("Move mine straight away, no prompt"),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName("countdown")
+      .setDescription("Move mine unless I hit Cancel in time")
+      .addIntegerOption((opt) =>
+        opt
+          .setName("seconds")
+          .setDescription("How long you get to cancel (1-300)")
+          .setMinValue(1)
+          .setMaxValue(300)
+          .setRequired(true),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName("ask")
+      .setDescription("Ask me first, and leave it put if I say nothing")
+      .addIntegerOption((opt) =>
+        opt
+          .setName("seconds")
+          .setDescription("How long the prompt waits (1-300)")
+          .setMinValue(1)
+          .setMaxValue(300)
+          .setRequired(true),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub.setName("never").setDescription("Never move mine, and never prompt me"),
+  )
+  .addSubcommand((sub) => sub.setName("show").setDescription("Show what is set for you right now"))
+  .addSubcommand((sub) =>
+    sub.setName("clear").setDescription("Drop yours and follow the server default"),
+  )
+  .setContexts(InteractionContextType.Guild);
+
+/**
+ * Builds the preference to persist from the chosen subcommand.
+ * @param mode - The subcommand the member ran.
+ * @param [seconds] - Seconds supplied with countdown or ask.
+ * @returns The {@link MemberPref} to store; `seconds` is dropped for the modes
+ * that have no timing of their own.
+ */
+export function resolvePref(mode: MemberMode, seconds?: number | null): MemberPref {
+  if (mode === "instant" || mode === "never") return { mode };
+  return { mode, seconds: Number(seconds ?? 10) };
+}
+
+/**
+ * Describes the guild `/setdelay` behaviour in the second person, for replies
+ * that have to name what applies instead of a member's own choice.
+ * @param grace - The configured guild grace.
+ * @returns A sentence fragment describing it.
+ */
+function describeGuildDefault(grace: GraceSetting | undefined): string {
+  const g = grace ?? 10_000;
+  if (g === "instant") return "your links get moved straight away";
+  if (g === "disabled") return "you get asked, and the prompt waits forever";
+  return `you get ${Math.round((g as number) / 1000)}s to hit Yes before the prompt gives up`;
+}
+
+/**
+ * Describes a member's own setting in the second person.
+ * @param pref - The preference in force, after clamping.
+ * @returns A sentence fragment describing it.
+ */
+function describePref(pref: MemberPref): string {
+  switch (pref.mode) {
+    case "instant":
+      return "your links get moved straight away, no prompt";
+    case "countdown":
+      return `your links get moved after ${pref.seconds}s unless you hit Cancel`;
+    case "ask":
+      return `you get ${pref.seconds}s to hit Yes before the prompt gives up`;
+    case "never":
+      return "your links are never moved, and you are never prompted";
+  }
+}
+
+/**
+ * Answers `/mydelay show`: what is actually in force, which is not always what
+ * the member set - admin bounds are applied on read, so a stored choice can be
+ * clamped or ignored after the fact.
+ * @param interaction - The command interaction context.
+ * @param guildId - Discord guild ID.
+ * @returns A promise that resolves when the reply is sent.
+ */
+async function replyWithCurrent(
+  interaction: ChatInputCommandInteraction,
+  guildId: string,
+): Promise<void> {
+  const settings = loadSettings(guildId);
+  const stored = loadPref(guildId, interaction.user.id);
+  const effective = clampPref(stored, resolveLimits(settings));
+
+  let content: string;
+  if (!effective) {
+    content = stored
+      ? `⚙️ Your setting is not allowed here, so the server default applies: ${describeGuildDefault(settings.grace)}.`
+      : `⚙️ You are on the server default: ${describeGuildDefault(settings.grace)}.`;
+  } else {
+    const clamped = stored?.seconds !== undefined && stored.seconds !== effective.seconds;
+    content = `⚙️ In force for you: ${describePref(effective)}.${
+      clamped ? ` Your ${stored?.seconds}s was clamped to what this server allows.` : ""
+    }`;
+  }
+  await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+}
+
+/**
+ * Confirms a stored choice, naming the clamp when the value had to be pulled
+ * into the guild's bounds.
+ * @param pref - What the member asked for.
+ * @param limits - The bounds in force.
+ * @returns The confirmation text.
+ */
+function confirmation(pref: MemberPref, limits: PersonalLimits): string {
+  const clamped = clampPref(pref, limits);
+  const seconds = clamped?.seconds;
+  const wasClamped = seconds !== undefined && seconds !== pref.seconds;
+  switch (pref.mode) {
+    case "instant":
+      return "✅ Your links get moved straight away now, no prompt.";
+    case "never":
+      return "✅ Your links stay put, and you won't be prompted about them.";
+    default: {
+      const shown = describePref({ mode: pref.mode, seconds });
+      const note = wasClamped ? ` (${pref.seconds}s is over this server's limit.)` : "";
+      return `✅ ${shown[0].toUpperCase()}${shown.slice(1)}.${note}`;
+    }
+  }
+}
+
+/**
+ * Executes `/mydelay`: stores, shows, or drops the invoker's own preference
+ * for how their media links are handled.
+ * @param interaction - The command interaction context.
+ * @returns A promise that resolves when the reply has been sent.
+ */
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  if (!interaction.inGuild()) {
+    log.warn("invoked outside guild", { userId: interaction.user.id });
+    await interaction.reply({ content: "Use in a server.", flags: MessageFlags.Ephemeral });
+    return;
+  }
+
+  const guildId = interaction.guildId;
+  const userId = interaction.user.id;
+  const sub = interaction.options.getSubcommand() as MemberMode | "show" | "clear";
+
+  try {
+    const settings = loadSettings(guildId);
+    const limits = resolveLimits(settings);
+
+    if (sub === "show") {
+      await replyWithCurrent(interaction, guildId);
+      return;
+    }
+
+    if (sub === "clear") {
+      clearPref(guildId, userId);
+      await interaction.reply({
+        content: `✅ Dropped. You're on the server default now: ${describeGuildDefault(settings.grace)}.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (!limits.enabled) {
+      await interaction.reply({
+        content: `❌ This server doesn't let members set their own delay. The server default applies: ${describeGuildDefault(settings.grace)}.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (sub === "never" && !limits.allowNever) {
+      await interaction.reply({
+        content: `❌ This server doesn't allow opting out of moves. The server default applies: ${describeGuildDefault(settings.grace)}.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const seconds =
+      sub === "countdown" || sub === "ask" ? interaction.options.getInteger("seconds", true) : null;
+    const pref = resolvePref(sub, seconds);
+    savePref(guildId, userId, pref);
+    log.info("member preference updated", { guildId, userId, mode: pref.mode, seconds });
+
+    await interaction.reply({
+      content: confirmation(pref, limits),
+      flags: MessageFlags.Ephemeral,
+    });
+  } catch (err) {
+    log.error("failed to update member preference", {
+      guildId,
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    await interaction.reply({
+      content: "⚠️ There was an error.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+}

--- a/src/commands/setdelay.ts
+++ b/src/commands/setdelay.ts
@@ -1,12 +1,13 @@
 // src/commands/setdelay.ts
 
+import { resolveLimits } from "@/media/prefs";
 import { loadSettings, saveSettings } from "@/media/settings";
-import { GraceSetting } from "@/media/types";
+import { GraceSetting, PersonalLimits } from "@/media/types";
 import { createLogger } from "@/utils/log";
 import { requireAdmin } from "@/utils/permissions";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { InteractionContextType } from "discord-api-types/v10";
-import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import { ChatInputCommandInteraction, MessageFlags, PermissionFlagsBits } from "discord.js";
 
 const log = createLogger("cmd/setdelay");
 
@@ -16,6 +17,9 @@ const log = createLogger("cmd/setdelay");
  * - `/setdelay instant` - move links immediately, no prompt
  * - `/setdelay seconds seconds:<1-300>` - prompt that times out
  * - `/setdelay disabled` - prompt that waits forever
+ *
+ * `/setdelay personal` sits alongside them, governing what members may pick
+ * for themselves with `/mydelay` rather than the default itself.
  */
 export const data = new SlashCommandBuilder()
   .setName("setdelay")
@@ -39,7 +43,52 @@ export const data = new SlashCommandBuilder()
   .addSubcommand((sub) =>
     sub.setName("disabled").setDescription("Always ask, and wait forever for an answer"),
   )
+  .addSubcommand((sub) =>
+    sub
+      .setName("personal")
+      .setDescription("What members may set for themselves with /mydelay")
+      .addBooleanOption((opt) =>
+        opt.setName("enabled").setDescription("Let members set their own delay"),
+      )
+      .addIntegerOption((opt) =>
+        opt
+          .setName("max-seconds")
+          .setDescription("Longest delay a member may pick (1-300)")
+          .setMinValue(1)
+          .setMaxValue(300),
+      )
+      .addBooleanOption((opt) =>
+        opt.setName("allow-never").setDescription("Let members opt out of moves entirely"),
+      ),
+  )
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
   .setContexts(InteractionContextType.Guild);
+
+/**
+ * Applies the supplied `/setdelay personal` options to the bounds already in
+ * force. Every option is optional, so `null` (nothing supplied) leaves the
+ * current value alone.
+ * @param current - The bounds in force.
+ * @param changes - The options as Discord returned them.
+ * @param changes.enabled - Whether members may set their own delay.
+ * @param changes.maxSeconds - Longest delay a member may pick.
+ * @param changes.allowNever - Whether members may opt out of moves entirely.
+ * @returns The {@link PersonalLimits} to persist.
+ */
+export function mergePersonal(
+  current: PersonalLimits,
+  changes: {
+    enabled?: boolean | null;
+    maxSeconds?: number | null;
+    allowNever?: boolean | null;
+  },
+): PersonalLimits {
+  return {
+    enabled: changes.enabled ?? current.enabled,
+    maxSeconds: changes.maxSeconds ?? current.maxSeconds,
+    allowNever: changes.allowNever ?? current.allowNever,
+  };
+}
 
 /**
  * Converts the chosen subcommand/value into the persisted grace
@@ -78,7 +127,14 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     return;
   }
 
-  const mode = interaction.options.getSubcommand() as "instant" | "disabled" | "seconds";
+  const mode = interaction.options.getSubcommand() as
+    "instant" | "disabled" | "seconds" | "personal";
+
+  if (mode === "personal") {
+    await setPersonal(interaction, guildId);
+    return;
+  }
+
   const seconds = mode === "seconds" ? interaction.options.getInteger("seconds", true) : null;
 
   try {
@@ -88,7 +144,7 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
 
     log.info("grace updated", { guildId, by: userId, mode, seconds });
 
-    const confirmations: Record<typeof mode, string> = {
+    const confirmations: Record<"instant" | "seconds" | "disabled", string> = {
       instant: "✅ Links get moved straight away now, no prompt.",
       seconds: `✅ Posters get ${seconds}s to hit Yes or No before the prompt gives up.`,
       disabled: "✅ Posters always get asked, and the prompt waits forever.",
@@ -98,6 +154,51 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     log.error("failed to update grace", {
       guildId,
       userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    await interaction.reply({
+      content: "⚠️ There was an error.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+}
+
+/**
+ * Handles `/setdelay personal`: stores the bounds on what members may set for
+ * themselves. Tightening them applies to preferences members already saved,
+ * since the bounds are re-applied every time a preference is read.
+ * @param interaction - The command interaction context.
+ * @param guildId - Discord guild ID.
+ * @returns A promise that resolves when the reply has been sent.
+ */
+async function setPersonal(
+  interaction: ChatInputCommandInteraction,
+  guildId: string,
+): Promise<void> {
+  try {
+    const settings = loadSettings(guildId);
+    const next = mergePersonal(resolveLimits(settings), {
+      enabled: interaction.options.getBoolean("enabled"),
+      maxSeconds: interaction.options.getInteger("max-seconds"),
+      allowNever: interaction.options.getBoolean("allow-never"),
+    });
+    settings.personal = next;
+    saveSettings(guildId, settings);
+
+    log.info("personal limits updated", { guildId, by: interaction.user.id, ...next });
+
+    await interaction.reply({
+      content: next.enabled
+        ? `✅ Members can set their own delay with \`/mydelay\`, up to ${next.maxSeconds}s${
+            next.allowNever ? ", and can opt out entirely" : ", but cannot opt out entirely"
+          }.`
+        : "✅ Members can't set their own delay; everyone follows the server default.",
+      flags: MessageFlags.Ephemeral,
+    });
+  } catch (err) {
+    log.error("failed to update personal limits", {
+      guildId,
+      userId: interaction.user.id,
       error: err instanceof Error ? err.message : String(err),
     });
     await interaction.reply({

--- a/src/commands/setmediachannel.ts
+++ b/src/commands/setmediachannel.ts
@@ -5,7 +5,13 @@ import { createLogger } from "@/utils/log";
 import { requireAdmin } from "@/utils/permissions";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { InteractionContextType } from "discord-api-types/v10";
-import { ChannelType, ChatInputCommandInteraction, MessageFlags, TextChannel } from "discord.js";
+import {
+  ChannelType,
+  ChatInputCommandInteraction,
+  MessageFlags,
+  PermissionFlagsBits,
+  TextChannel,
+} from "discord.js";
 
 const log = createLogger("cmd/setmediachannel");
 
@@ -23,6 +29,7 @@ export const data = new SlashCommandBuilder()
       .addChannelTypes(ChannelType.GuildText)
       .setRequired(true),
   )
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
   .setContexts(InteractionContextType.Guild);
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,23 +8,19 @@ import {
 } from "@/media/repostActions";
 import { onMessage, onMessageEdit } from "@/onMessage";
 import { onMessageDelete } from "@/onMessageDelete";
+import type { CommandModule } from "@/types/discord";
 import { createLogger } from "@/utils/log";
-import { ContextMenuCommandBuilder } from "@discordjs/builders";
 import { REST } from "@discordjs/rest";
 import { RESTPostAPIApplicationCommandsJSONBody, Routes } from "discord-api-types/v10";
 import {
-  AutocompleteInteraction,
-  ChatInputCommandInteraction,
   Client,
   Collection,
   GatewayIntentBits,
   Interaction,
   InteractionReplyOptions,
   Message,
-  MessageContextMenuCommandInteraction,
   MessageFlags,
   Partials,
-  SlashCommandBuilder,
 } from "discord.js";
 import * as dotenv from "dotenv";
 import { readdirSync } from "fs";
@@ -64,19 +60,6 @@ if (!BOT_TOKEN || !CLIENT_ID) {
   process.exit(1);
 }
 
-declare module "discord.js" {
-  interface Client {
-    commands: Collection<
-      string,
-      {
-        data: SlashCommandBuilder | ContextMenuCommandBuilder;
-        execute: (interaction: CommandInteractionOfAnyKind) => Promise<void>;
-        autocomplete?: (interaction: AutocompleteInteraction) => Promise<void>;
-      }
-    >;
-  }
-}
-
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
@@ -92,16 +75,6 @@ const rest = new REST({ version: "10" }).setToken(BOT_TOKEN);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Either kind of command Discord dispatches to `execute`: a slash command, or
-// a right-click entry on a message (Apps > Edit post / Delete post).
-type CommandInteractionOfAnyKind =
-  ChatInputCommandInteraction | MessageContextMenuCommandInteraction;
-
-interface CommandModule {
-  data: SlashCommandBuilder | ContextMenuCommandBuilder;
-  execute: (interaction: CommandInteractionOfAnyKind) => Promise<void>;
-  autocomplete?: (interaction: AutocompleteInteraction) => Promise<void>;
-}
 type JSONCommand = RESTPostAPIApplicationCommandsJSONBody;
 
 {

--- a/src/media/approval.ts
+++ b/src/media/approval.ts
@@ -3,7 +3,7 @@
 // Button prompts with grace handling: requestChoice takes any button set and
 // returns which one was clicked. Only the intended author's clicks count.
 
-import { ApprovalOptions, GraceSetting } from "@/media/types";
+import { ApprovalOptions, ApprovalPlan, GraceSetting } from "@/media/types";
 import { createLogger } from "@/utils/log";
 import {
   ActionRowBuilder,
@@ -34,6 +34,26 @@ export interface ChoiceButton {
 export interface ChoiceOutcome {
   /** The clicked button's id, or null on timeout or send failure. */
   choice: string | null;
+  /**
+   * Whether the prompt reached the channel. False when the send failed, which
+   * a countdown must not read as consent - see {@link isApproved}.
+   */
+  prompted: boolean;
+}
+
+/**
+ * Reads a prompt's outcome against its plan. A countdown moves the link
+ * unless it was cancelled, so it needs the prompt to have actually been seen;
+ * every other plan needs an explicit yes. The "copy" choice never reaches
+ * here - the caller hands the link over and returns first.
+ * @param plan - The plan the prompt ran under.
+ * @param outcome - What {@link requestChoice} returned.
+ * @returns Whether to go ahead with the move.
+ */
+export function isApproved(plan: ApprovalPlan, outcome: ChoiceOutcome): boolean {
+  return plan.approveOnTimeout
+    ? outcome.prompted && outcome.choice !== "no"
+    : outcome.choice === "yes";
 }
 
 /**
@@ -86,7 +106,7 @@ export async function requestChoice(
   // Instant path: resolve without showing UI
   if (grace === "instant") {
     log.debug("instant choice", { channelId: channel.id, userId: author.id });
-    return { choice: opts.instantChoice ?? null };
+    return { choice: opts.instantChoice ?? null, prompted: false };
   }
 
   const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -109,7 +129,7 @@ export async function requestChoice(
       channelId: channel.id,
       userId: author.id,
     });
-    return { choice: null };
+    return { choice: null, prompted: false };
   }
 
   // Collector config
@@ -150,7 +170,7 @@ export async function requestChoice(
         await msg.edit({ components: [] }).catch(() => {});
         log.debug("prompt buttons cleared", { messageId: msg.id });
       }
-      resolve({ choice });
+      resolve({ choice, prompted: true });
     });
   });
 }

--- a/src/media/copyLink.ts
+++ b/src/media/copyLink.ts
@@ -8,8 +8,11 @@
  * block so Discord renders no embed and mobile clients show a copy button.
  * @param url - The link to hand over.
  * @param lead - Line shown above the fenced URL, naming what was done to it.
+ * @param [footer] - Subtext line under the block, for a hint the poster can act
+ * on. Omitted where there is nothing useful to offer.
  * @returns The message content to send.
  */
-export function buildCopyMessage(url: string, lead: string): string {
-  return `${lead}\n\`\`\`\n${url}\n\`\`\``;
+export function buildCopyMessage(url: string, lead: string, footer?: string): string {
+  const body = `${lead}\n\`\`\`\n${url}\n\`\`\``;
+  return footer ? `${body}\n${footer}` : body;
 }

--- a/src/media/prefs.ts
+++ b/src/media/prefs.ts
@@ -1,0 +1,102 @@
+// src/media/prefs.ts
+
+// Per-member move preferences: what each member picked for their own media
+// links, and the admin bounds that decide how much of it actually applies.
+
+import { MediaSettings, MemberPref, PersonalLimits } from "@/media/types";
+import { loadData, saveData } from "@/utils/file";
+import { createLogger } from "@/utils/log";
+
+const log = createLogger("media/prefs");
+
+/** Filename for persisted member preferences, keyed by user ID. */
+export const PREFS_FILE = "media_prefs.json";
+
+/**
+ * Bounds applied when a guild has never run `/setdelay personal`. Members may
+ * set a preference with no admin setup, on the reasoning that nothing changes
+ * for a guild until one of its members actually does.
+ */
+export const DEFAULT_PERSONAL_LIMITS: PersonalLimits = {
+  enabled: true,
+  maxSeconds: 300,
+  allowNever: true,
+};
+
+type PrefMap = Record<string, MemberPref>;
+
+/**
+ * Loads the guild's preference map, tolerating a missing or corrupt file.
+ * @param guildId - Discord guild ID.
+ * @returns Map of user ID to {@link MemberPref}.
+ */
+function loadMap(guildId: string): PrefMap {
+  return loadData<PrefMap>(guildId, PREFS_FILE, { soft: true, defaultValue: {} });
+}
+
+/**
+ * Reads a member's stored preference, exactly as they set it.
+ * @param guildId - Discord guild ID.
+ * @param userId - The member's user ID.
+ * @returns The stored {@link MemberPref}, or `undefined` when they have none.
+ */
+export function loadPref(guildId: string, userId: string): MemberPref | undefined {
+  return loadMap(guildId)[userId];
+}
+
+/**
+ * Stores a member's preference, replacing any previous one.
+ * @param guildId - Discord guild ID.
+ * @param userId - The member's user ID.
+ * @param pref - The {@link MemberPref} to persist.
+ */
+export function savePref(guildId: string, userId: string, pref: MemberPref): void {
+  const map = loadMap(guildId);
+  map[userId] = pref;
+  saveData(guildId, PREFS_FILE, map);
+  log.info("saved member preference", { guildId, userId, mode: pref.mode, seconds: pref.seconds });
+}
+
+/**
+ * Drops a member's preference so the guild default applies to them again.
+ * @param guildId - Discord guild ID.
+ * @param userId - The member's user ID.
+ */
+export function clearPref(guildId: string, userId: string): void {
+  const map = loadMap(guildId);
+  if (!(userId in map)) return;
+  delete map[userId];
+  saveData(guildId, PREFS_FILE, map);
+  log.info("cleared member preference", { guildId, userId });
+}
+
+/**
+ * Resolves the bounds in force for a guild.
+ * @param settings - Stored guild settings.
+ * @returns The stored {@link PersonalLimits}, or {@link DEFAULT_PERSONAL_LIMITS}.
+ */
+export function resolveLimits(settings: MediaSettings): PersonalLimits {
+  return settings.personal ?? DEFAULT_PERSONAL_LIMITS;
+}
+
+/**
+ * Applies the admin bounds to a stored preference. Clamping happens on read
+ * rather than only on write, so tightening the bounds reaches preferences
+ * members saved while they were looser.
+ * @param pref - The member's stored preference, if they have one.
+ * @param limits - The bounds in force for the guild.
+ * @returns The preference to act on, or `undefined` when the guild default
+ * should apply instead.
+ */
+export function clampPref(
+  pref: MemberPref | undefined,
+  limits: PersonalLimits,
+): MemberPref | undefined {
+  if (!pref || !limits.enabled) return undefined;
+  if (pref.mode === "never") return limits.allowNever ? pref : undefined;
+  if (pref.mode === "instant") return pref;
+
+  const max = Math.max(1, limits.maxSeconds);
+  const wanted = Number.isFinite(pref.seconds) ? (pref.seconds as number) : 10;
+  return { mode: pref.mode, seconds: Math.min(max, Math.max(1, Math.round(wanted))) };
+}

--- a/src/media/settings.ts
+++ b/src/media/settings.ts
@@ -1,10 +1,10 @@
 // src/media/settings.ts
 
-/**
- * @file Loads and resolves per-guild media settings.
- */
+// Loads per-guild media settings and resolves them, together with a member's
+// own preference, into the plan for one message.
 
-import { ApprovalPlan, GraceSetting, MediaSettings } from "@/media/types";
+import { clampPref, resolveLimits } from "@/media/prefs";
+import { ApprovalPlan, GraceSetting, MediaSettings, MemberPref } from "@/media/types";
 import { loadData, saveData } from "@/utils/file";
 import { createLogger } from "@/utils/log";
 
@@ -76,6 +76,7 @@ export function resolveApprovalPlan(
       autoApprove: false,
       timeoutMs: 15_000,
       persistIndefinitely: false,
+      approveOnTimeout: false,
       promptText: "Rewrite your link here with an embeddable version?",
     };
     log.debug("approval plan (same channel)", { plan });
@@ -89,6 +90,7 @@ export function resolveApprovalPlan(
       autoApprove: true,
       timeoutMs: undefined,
       persistIndefinitely: false,
+      approveOnTimeout: false,
       promptText: "Move your media link to the media channel?",
     };
   } else if (g === "disabled") {
@@ -96,6 +98,7 @@ export function resolveApprovalPlan(
       autoApprove: false,
       timeoutMs: undefined,
       persistIndefinitely: true,
+      approveOnTimeout: false,
       promptText: "Move your media link to the media channel?",
     };
   } else {
@@ -104,9 +107,56 @@ export function resolveApprovalPlan(
       autoApprove: false,
       timeoutMs: ms,
       persistIndefinitely: false,
+      approveOnTimeout: false,
       promptText: "Move your media link to the media channel?",
     };
   }
   log.debug("approval plan", { sameChannel, grace: g, plan });
   return plan;
+}
+
+/**
+ * Resolves the plan for one message: a member's own preference when it
+ * applies, otherwise the guild `/setdelay` default. Member preferences govern
+ * cross-channel moves only, so a same-channel rewrite never consults one.
+ * @param settings - Stored guild settings.
+ * @param pref - The poster's stored preference, if they have one.
+ * @param sameChannel - Whether the repost target is the source channel.
+ * @returns The {@link ApprovalPlan} to run, or `null` when the poster opted
+ * out of moves entirely and nothing should happen.
+ */
+export function resolvePlanFor(
+  settings: MediaSettings,
+  pref: MemberPref | undefined,
+  sameChannel: boolean,
+): ApprovalPlan | null {
+  const guildPlan = resolveApprovalPlan(settings.grace, sameChannel);
+  if (sameChannel) return guildPlan;
+
+  const effective = clampPref(pref, resolveLimits(settings));
+  if (!effective) return guildPlan;
+
+  log.debug("member preference applies", { mode: effective.mode, seconds: effective.seconds });
+  switch (effective.mode) {
+    case "never":
+      return null;
+    case "instant":
+      return { ...guildPlan, autoApprove: true, timeoutMs: undefined, persistIndefinitely: false };
+    case "countdown":
+      return {
+        autoApprove: false,
+        approveOnTimeout: true,
+        timeoutMs: (effective.seconds ?? 10) * 1000,
+        persistIndefinitely: false,
+        promptText: "Moving your media link to the media channel - hit Cancel to keep it here.",
+      };
+    case "ask":
+      return {
+        autoApprove: false,
+        approveOnTimeout: false,
+        timeoutMs: (effective.seconds ?? 10) * 1000,
+        persistIndefinitely: false,
+        promptText: "Move your media link to the media channel?",
+      };
+  }
 }

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -1,8 +1,6 @@
 // src/media/types.ts
 
-/**
- * @file Shared types for the media workflow.
- */
+// Shared types for the media workflow.
 
 import { Message } from "discord.js";
 
@@ -30,11 +28,35 @@ export type ServiceKey =
  */
 export type GraceSetting = "instant" | "disabled" | number;
 
+/**
+ * How a member wants their own media links handled on a cross-channel move:
+ * - "instant": move it straight away, no prompt
+ * - "countdown": show a Cancel prompt, and move it when the time runs out
+ * - "ask": show a Yes/No prompt, and leave it put on silence
+ * - "never": leave it put, without prompting at all
+ */
+export type MemberMode = "instant" | "countdown" | "ask" | "never";
+
+/** A member's stored choice. `seconds` applies to countdown and ask only. */
+export interface MemberPref {
+  mode: MemberMode;
+  seconds?: number;
+}
+
+/** Guild-wide switch and bounds on what members may pick for themselves. */
+export interface PersonalLimits {
+  enabled: boolean;
+  maxSeconds: number;
+  allowNever: boolean;
+}
+
 /** Stored settings per guild. */
 export interface MediaSettings {
   /** Destination channel for reposts; if absent, use source channel. */
   channelId?: string;
   grace?: GraceSetting;
+  /** Bounds on member preferences; absent means the defaults in prefs.ts. */
+  personal?: PersonalLimits;
 }
 
 /** Result of matching a supported link inside content. */
@@ -65,6 +87,8 @@ export interface ApprovalPlan {
   timeoutMs?: number;
   persistIndefinitely: boolean;
   promptText: string;
+  /** Running out of time counts as approval. Set by countdown mode. */
+  approveOnTimeout: boolean;
 }
 
 /** Outcome of posting a repost + optional source-channel pointer. */

--- a/src/media/workflow.ts
+++ b/src/media/workflow.ts
@@ -3,12 +3,13 @@
 // Orchestrates media-link handling for a single message. Splits
 // responsibilities across match/transform/settings/approval/repost/audit.
 
-import { ChoiceButton, requestChoice } from "@/media/approval";
+import { ChoiceButton, isApproved, requestChoice } from "@/media/approval";
 import { buildCopyMessage } from "@/media/copyLink";
 import { matchAny } from "@/media/match";
+import { loadPref } from "@/media/prefs";
 import { repostWithOptionalStub } from "@/media/repost";
 import { registerRepostActions } from "@/media/repostActions";
-import { loadSettings, resolveApprovalPlan, resolveTargetChannelId } from "@/media/settings";
+import { loadSettings, resolvePlanFor, resolveTargetChannelId } from "@/media/settings";
 import { rewriteContent } from "@/media/transform";
 import { createLogger } from "@/utils/log";
 import { ButtonStyle, GuildTextBasedChannel, Message } from "discord.js";
@@ -32,11 +33,36 @@ const MEDIA_BUTTONS: ChoiceButton[] = [
   { id: "no", label: "No", style: ButtonStyle.Danger },
 ];
 
+/**
+ * Buttons on a countdown prompt, where silence means yes and the only answer
+ * that changes anything is a refusal. Cancel carries the id "no", so the
+ * negative answer is one id across both button sets and only the label differs.
+ */
+const COUNTDOWN_BUTTONS: ChoiceButton[] = [
+  { id: "no", label: "Cancel", style: ButtonStyle.Danger },
+  { id: "copy", label: "Copy", emoji: "📋", style: ButtonStyle.Secondary },
+];
+
 /** Line above the copied link, naming what the bot did to it. */
 const COPY_LEAD = {
   tracking: "Here's your link without the tracking junk:",
   media: "Here's your embeddable link:",
 } as const;
+
+/** Subtext under a copied link, naming the command that governs the move. */
+const MYDELAY_HINT = "-# Tune how this works for you with /mydelay";
+
+/**
+ * Picks the subtext for the copy hand-over. `/mydelay` governs cross-channel
+ * moves only, so advertising it anywhere else would promise control it does
+ * not have.
+ * @param isTrackingClean - Whether this is a tracking clean rather than media.
+ * @param sameChannel - Whether the repost target is the source channel.
+ * @returns The hint line, or `undefined` when there is nothing to offer.
+ */
+export function copyHintFor(isTrackingClean: boolean, sameChannel: boolean): string | undefined {
+  return isTrackingClean || sameChannel ? undefined : MYDELAY_HINT;
+}
 
 /**
  * Handles a message: detect media links, get approval, and repost/notify.
@@ -72,8 +98,20 @@ export async function handleMediaMessage(message: Message): Promise<void> {
   // Prepare rewrite
   const rewrite = rewriteContent(message.content, match, message.author.id);
 
-  // Build approval plan (handles same-channel overrides)
-  const plan = resolveApprovalPlan(settings.grace, sameChannel);
+  // Build the approval plan: the poster's own preference on a cross-channel
+  // move, else the guild default (which handles the same-channel overrides).
+  const plan = resolvePlanFor(
+    settings,
+    sameChannel ? undefined : loadPref(message.guildId!, message.author.id),
+    sameChannel,
+  );
+  if (!plan) {
+    log.debug("poster opted out of moves", {
+      guildId: message.guildId!,
+      userId: message.author.id,
+    });
+    return;
+  }
   if (isTrackingClean) plan.promptText = "Clean the tracking junk out of your link?";
 
   // Auto-approve or ask. Every prompt offers a third option: hand the poster
@@ -81,10 +119,10 @@ export async function handleMediaMessage(message: Message): Promise<void> {
   // cleans always prompt, since the same-channel plan never auto-approves.
   let approved = plan.autoApprove;
   if (!approved) {
-    const { choice } = await requestChoice(
+    const outcome = await requestChoice(
       source,
       message.author,
-      isTrackingClean ? CLEAN_BUTTONS : MEDIA_BUTTONS,
+      isTrackingClean ? CLEAN_BUTTONS : plan.approveOnTimeout ? COUNTDOWN_BUTTONS : MEDIA_BUTTONS,
       {
         prompt: plan.promptText,
         grace: plan.persistIndefinitely ? "disabled" : (plan.timeoutMs ?? 10_000),
@@ -93,11 +131,12 @@ export async function handleMediaMessage(message: Message): Promise<void> {
           copy: buildCopyMessage(
             rewrite.newLink,
             isTrackingClean ? COPY_LEAD.tracking : COPY_LEAD.media,
+            copyHintFor(isTrackingClean, sameChannel),
           ),
         },
       },
     );
-    if (choice === "copy") {
+    if (outcome.choice === "copy") {
       log.info("poster copied link", {
         guildId: message.guildId!,
         from: source.id,
@@ -105,7 +144,7 @@ export async function handleMediaMessage(message: Message): Promise<void> {
       });
       return;
     }
-    approved = choice === "yes";
+    approved = isApproved(plan, outcome);
   }
 
   log.debug("approval result", { approved, sameChannel, targetId });

--- a/src/types/discord.d.ts
+++ b/src/types/discord.d.ts
@@ -1,0 +1,35 @@
+// src/types/discord.d.ts
+
+// Declares Client.commands, the collection the loader fills. It lives here
+// rather than in index.ts so every programme that pulls in a command module
+// sees it: the smoke test's tsconfig covers scripts plus whatever they import,
+// which never reaches index.ts.
+
+import { ContextMenuCommandBuilder } from "@discordjs/builders";
+import {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  Collection,
+  MessageContextMenuCommandInteraction,
+  SlashCommandBuilder,
+} from "discord.js";
+
+/**
+ * Either kind of command Discord dispatches to `execute`: a slash command, or
+ * a right-click entry on a message (Apps > Edit post / Delete post).
+ */
+export type CommandInteractionOfAnyKind =
+  ChatInputCommandInteraction | MessageContextMenuCommandInteraction;
+
+/** A loaded command module: its definition plus the handlers the loader wires. */
+export interface CommandModule {
+  data: SlashCommandBuilder | ContextMenuCommandBuilder;
+  execute: (interaction: CommandInteractionOfAnyKind) => Promise<void>;
+  autocomplete?: (interaction: AutocompleteInteraction) => Promise<void>;
+}
+
+declare module "discord.js" {
+  interface Client {
+    commands: Collection<string, CommandModule>;
+  }
+}

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -12,6 +12,19 @@ import {
 const BOT_OWNER_ID = process.env.YOUR_ID;
 
 /**
+ * Subcommands that need admin on commands that are otherwise open to everyone,
+ * keyed by command name. Discord filters its picker per command rather than
+ * per subcommand, so these cannot be hidden the way a fully-admin command is;
+ * `/help` marks them instead. Keep in step with the {@link requireAdmin} calls
+ * in the command modules - a fully-admin command belongs in its builder's
+ * default permissions, not here.
+ */
+export const ADMIN_SUBCOMMANDS: Record<string, string[]> = {
+  slurs: ["nuke"],
+  swears: ["nuke"],
+};
+
+/**
  * Checks whether the invoker may run admin commands (settings, nukes).
  * Allowed: the bot owner ({@link BOT_OWNER_ID}), the guild owner, or a member
  * with Manage Server (Administrator implies it). Runtime check rather than


### PR DESCRIPTION
`/setdelay` is admin-only and guild-wide, so every member gets the same treatment. Members who always say Yes had to keep clicking Yes, and members who never want their links touched had to keep clicking No. There was also no "move it after N seconds" behaviour at all: a numeric grace means prompt, and do nothing when nobody answers.

## /mydelay

Any member, ephemeral, guild-only:

- `/mydelay instant` - moved straight away, no prompt.
- `/mydelay countdown seconds:<1-300>` - `[Cancel][Copy]` for N seconds, then moved.
- `/mydelay ask seconds:<1-300>` - the usual `[Yes][Copy][No]`, silence leaves it put.
- `/mydelay never` - never moved, never prompted. A hard skip, so the member sees nothing rather than a prompt they are expected to ignore.
- `/mydelay show` - what is actually active, which is not always what was typed.
- `/mydelay clear` - drop it and follow the server default.

Stored per guild in `data/<guildId>/media_prefs.json`, matching every other store. Admins keep a switch and bounds through `/setdelay personal [enabled] [max-seconds] [allow-never]`, defaulting to on / 300s / opt-out allowed so the feature works with no setup and nothing changes for a guild until one of its members opts in. Bounds are applied on read rather than only on write, so tightening them reaches preferences saved while they were looser.

Scope is cross-channel moves only. Same-channel rewrites and tracking cleans have nothing to do with a media channel, and folding them in would weld two unrelated features onto one setting.

## Countdown and consent

Countdown approves on silence, so a prompt that never reached the channel must not be read as consent or a failed send would move the link on its own. `ChoiceOutcome` gains `prompted` for exactly that, and `isApproved` reads an outcome against its plan. `Cancel` carries the id `no`, so the negative answer is one id across both button sets and only the label differs.

The copy hand-over now takes an optional footer and carries a `/mydelay` hint. It reaches someone already interacting with a prompt without adding channel noise, and it is omitted for tracking cleans and same-channel rewrites where the command would promise control it does not have.

## Admin command visibility

`/setdelay`, `/setmediachannel` and `/calmdown` now register with Manage Server as their default permission, so Discord keeps them out of a member's slash-command picker, and `/help` filters itself to match instead of advertising commands that are not there to be found.

Discord filters per command rather than per subcommand, so commands mixing open and admin subcommands cannot be hidden without taking their leaderboards with them. `/slurs nuke` and `/swears nuke` stay visible and are marked 🔒 instead, from an `ADMIN_SUBCOMMANDS` registry sat next to `requireAdmin`.

Two things to know. It is a default, not a lock: a server admin can still grant these per role, member or channel under Server Settings > Integrations, so the runtime checks stay. And the `YOUR_ID` owner grant is a runtime check Discord knows nothing about, so a bot owner holding neither ownership nor Manage Server loses reach on those three.

## Also

The `Client.commands` augmentation moves from `index.ts` to `src/types/discord.d.ts`. The smoke test's tsconfig covers `scripts` plus what they import, which never reached `index.ts`, so importing `help.ts` left the collection untyped. `index.ts` now imports `CommandModule` from there rather than redeclaring it.

Minor bump to 2.10.0. Verified with `npm run typecheck`, `npm run lint`, `npm run build` and all 163 smoke checks, 27 of them new. Not exercised against a live server.
