### PR TITLE
Gate admin commands at runtime, and stop a failed move losing the post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reactionbot",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reactionbot",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "dependencies": {
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactionbot",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "type": "module",
   "scripts": {
     "build": "node -e \"fs.rmSync('build',{recursive:true,force:true,maxRetries:10,retryDelay:200});fs.rmSync('tsconfig.tsbuildinfo',{force:true})\" && tsc && tsc-alias",

--- a/readme.md
+++ b/readme.md
@@ -59,10 +59,12 @@ denied package gets installed but not linked into `node_modules/.bin` on npm 11.
 break the root `prepare` script that calls it.
 
 Per-guild data (settings, counters, audit logs) is stored as JSON under `data/<guildId>/`, relative
-to the working directory. All word behaviour (trackers + reactions) lives in one file,
-`data/global/words.json` - see [data/readme.md](data/readme.md) for the full format, a template, and
-how to add words. It's gitignored (it contains the slur list), so copy your own file in on a fresh
-deploy.
+to the working directory. The two message-keyed stores age out rather than growing forever: a moved
+post stays editable/deletable by its author for 90 days, and a bot reply stays linked to the message
+that triggered it for 30. Both are pruned on write, off the message ID's own timestamp. All word
+behaviour (trackers + reactions) lives in one file, `data/global/words.json` - see
+[data/readme.md](data/readme.md) for the full format, a template, and how to add words. It's
+gitignored (it contains the slur list), so copy your own file in on a fresh deploy.
 
 ## Commands
 
@@ -71,20 +73,18 @@ deploy.
 Admin commands (settings and the nukes) require the bot owner (the `YOUR_ID` env var), the guild
 owner, or the Manage Server permission. Everything else works for anyone, in any channel.
 
-`/setdelay`, `/setmediachannel`, and `/calmdown` are registered with Manage Server as their default
-permission, so Discord keeps them out of the slash-command picker for everyone else and `/help`
-leaves them out to match. It is a default, not a lock - a server admin can grant them per role,
-member, or channel under Server Settings > Integrations, and the runtime check still applies either
-way. Two consequences worth knowing: the `YOUR_ID` owner grant cannot beat the picker, so in a
-server where the bot owner holds neither ownership nor Manage Server those commands are out of
-reach; and Discord filters per command rather than per subcommand, so commands that mix open and
-admin subcommands (`/slurs nuke`, `/swears nuke`) stay visible to everyone and are marked 🔒 in
-`/help` instead.
+Nothing is registered with a default member permission. Discord applies those before dispatching an
+interaction, which would shut the bot owner out of the very commands the `YOUR_ID` grant exists for,
+so every admin command is authorised at runtime instead - once centrally, before dispatch, and again
+inside the command. The trade-off is that `/setdelay`, `/setmediachannel`, and `/calmdown` sit in
+everyone's slash-command picker; a member who runs one is refused. `/help` does the hiding Discord
+no longer does: a member sees neither those commands nor the admin subcommands of an otherwise open
+one (`/slurs nuke`, `/swears nuke`), and an admin sees both, marked 🔒.
 
 - `/setmediachannel` - set which text channel media links get reposted into.
 - `/setdelay instant` - move links straight away without asking.
 - `/setdelay seconds seconds:<1-300>` - give the poster that long to hit Yes or No.
-- `/setdelay disabled` - always ask, and wait forever for an answer.
+- `/setdelay disabled` - always ask, and leave the prompt up for a day (unanswered = left alone).
 - `/setdelay personal [enabled] [max-seconds] [allow-never]` - what members may set for themselves
   with `/mydelay`. Every option is optional; only the ones you supply change. Defaults to on, up to
   300s, opt-out allowed.
@@ -99,7 +99,7 @@ admin subcommands (`/slurs nuke`, `/swears nuke`) stay visible to everyone and a
   reply fires (5 hits in 30s across all users, sent once per episode), so a flood gets one "enough"
   and then quiet for 5 minutes or 20 messages, whichever comes first - tune per server with
   `/calmdown auto [minutes] [messages]`.
-- `/help` - list the commands you can run, with 🔒 on admin-only subcommands.
+- `/help` - list the commands you can run. An admin also sees the admin-only ones, marked 🔒.
 
 ### Right-click a moved post
 

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -20,7 +20,12 @@ import { stripTracking } from "@/media/cleanTracking";
 import { buildCopyMessage } from "@/media/copyLink";
 import { matchAny } from "@/media/match";
 import { clampPref, clearPref, loadPref, savePref } from "@/media/prefs";
-import { buildMovedContent, buildPointerContent, collectMentions } from "@/media/repost";
+import {
+  buildMovedContent,
+  buildPointerContent,
+  collectMentions,
+  repostWithOptionalStub,
+} from "@/media/repost";
 import { findRepostForMessage, getRepost, removeRepost, saveRepost } from "@/media/repostStore";
 import { resolvePlanFor } from "@/media/settings";
 import { buildTransformedUrl, rewriteContent } from "@/media/transform";
@@ -49,9 +54,11 @@ import { getTopWords, getUserTotal, incrementCounts } from "@/tracking/store";
 import { phraseToEmojis, resolveReactions } from "@/tracking/track";
 import { SLURS, SWEARS } from "@/tracking/trackers";
 import { loadWords, parseJsonc } from "@/tracking/words";
+import { ADMIN_COMMANDS, ADMIN_SUBCOMMANDS, needsAdmin } from "@/utils/permissions";
 import { recordReply, takeReplies } from "@/utils/replyStore";
+import { pruneByKeyAge, snowflakeTime } from "@/utils/retention";
 import { ApplicationCommandOptionType, ApplicationCommandType } from "discord-api-types/v10";
-import { PermissionFlagsBits } from "discord.js";
+import type { GuildTextBasedChannel, Message } from "discord.js";
 import { mkdirSync, readdirSync, rmSync, writeFileSync } from "fs";
 import path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
@@ -270,6 +277,27 @@ function checkLinkTransforms(): void {
       rewriteContent("https://x.com/u/status/1?s=20&t=trackme", socialTail).rewrittenText ===
         "https://fixupx.com/u/status/1",
   );
+
+  // "$&" and friends are substitution patterns to String.replace, and a URL
+  // path may hold them, so the rewritten link has to go in through a function
+  // rather than as a replacement string.
+  const dollarTracked = "https://example.com/a$&b?utm_source=x";
+  const dollarMatch = matchAny(dollarTracked);
+  check(
+    "tracking",
+    "a $ in a cleaned link is inserted literally",
+    dollarMatch !== null &&
+      rewriteContent(dollarTracked, dollarMatch).rewrittenText === "https://example.com/a$&b",
+  );
+  const dollarPost = "https://www.tumblr.com/blog/123/my$&slug";
+  const dollarPlatform = matchAny(dollarPost);
+  check(
+    "tracking",
+    "a $ in a platform link survives the rewrite",
+    dollarPlatform !== null &&
+      rewriteContent(dollarPost, dollarPlatform).rewrittenText ===
+        "https://tpmblr.com/blog/123/my$&slug",
+  );
 }
 
 /**
@@ -323,6 +351,148 @@ function checkRepostContent(): void {
     "copy hand-off fences the link under its lead line",
     buildCopyMessage(clean, "Here you go:") === `Here you go:\n\`\`\`\n${clean}\n\`\`\``,
   );
+}
+
+/**
+ * Builds the fakes {@link repostWithOptionalStub} touches, with a scripted send.
+ * @param send - Stands in for the target channel's send, resolving with a moved
+ * message or rejecting the way Discord would.
+ * @returns The fake original and channels, plus a reader for whether the
+ * original ended up deleted.
+ */
+function fakeMove(send: () => Promise<unknown>): {
+  original: Message<true>;
+  source: GuildTextBasedChannel;
+  target: GuildTextBasedChannel;
+  deleted: () => boolean;
+} {
+  let deleted = false;
+  const original = {
+    id: "orig1",
+    author: { id: "1" },
+    content: "look https://x.com/a/status/1",
+    attachments: new Map(),
+    delete: async () => {
+      deleted = true;
+      return original;
+    },
+  };
+  const source = { id: "c1", send: async () => ({ id: "stub1" }) };
+  const target = { id: "c2", send };
+  return {
+    original: original as unknown as Message<true>,
+    source: source as unknown as GuildTextBasedChannel,
+    target: target as unknown as GuildTextBasedChannel,
+    deleted: () => deleted,
+  };
+}
+
+/**
+ * Verifies the move's ordering. The poster's message is deleted for them, so a
+ * send that fails - the "from <@id>" prefix pushing a near-limit message past
+ * 2000 characters, a missing permission in the target - must leave it where it
+ * is rather than destroy it with nothing put back.
+ */
+async function checkRepostOrdering(): Promise<void> {
+  const failing = fakeMove(() => Promise.reject(new Error("Invalid Form Body: content too long")));
+  const refused = await repostWithOptionalStub(
+    failing.original,
+    "look https://fixupx.com/a/status/1",
+    failing.source,
+    failing.target,
+    true,
+  );
+  check("repost", "a failed post moves nothing", refused.moved === undefined);
+  check("repost", "a failed post leaves the original in place", !failing.deleted());
+
+  const working = fakeMove(() =>
+    Promise.resolve({ id: "moved1", url: "https://discord.com/channels/1/2/3" }),
+  );
+  const done = await repostWithOptionalStub(
+    working.original,
+    "look https://fixupx.com/a/status/1",
+    working.source,
+    working.target,
+    true,
+  );
+  check("repost", "a successful post returns the moved message", done.moved?.id === "moved1");
+  check("repost", "a successful post deletes the original", working.deleted());
+  check("repost", "a successful cross-channel post leaves a pointer", done.stub?.id === "stub1");
+}
+
+/**
+ * Builds the snowflake Discord would have minted at the given time.
+ * @param epochMs - When the message was posted, in epoch ms.
+ * @returns The message ID a post at that moment would carry.
+ */
+function snowflakeAt(epochMs: number): string {
+  return String(BigInt(epochMs - 1_420_070_400_000) << 22n);
+}
+
+/**
+ * Verifies the message-keyed stores prune themselves. An entry is only ever
+ * released when its own message is deleted, which for most never happens, so
+ * without an age rule both files grow for the life of the guild.
+ */
+function checkRetention(): void {
+  const now = Date.now();
+  const day = 24 * 60 * 60_000;
+
+  const minted = now - 5 * day;
+  check(
+    "retention",
+    "a snowflake reports the time it was minted",
+    snowflakeTime(snowflakeAt(minted)) === minted,
+  );
+  check("retention", "a non-snowflake has no readable age", snowflakeTime("m1") === null);
+
+  const fresh = snowflakeAt(now - day);
+  const stale = snowflakeAt(now - 100 * day);
+  const pruned = pruneByKeyAge({ [fresh]: 1, [stale]: 2, m1: 3 }, 90 * day, now);
+  check(
+    "retention",
+    "pruning drops what is past the window and keeps the rest",
+    pruned.dropped === 1 && pruned.kept[fresh] === 1 && pruned.kept[stale] === undefined,
+  );
+  check(
+    "retention",
+    "an entry with no readable age is kept",
+    pruned.kept.m1 === 3 && Object.keys(pruned.kept).length === 2,
+  );
+
+  const guild = "__smoketest__";
+  const record = {
+    authorId: "u1",
+    originalMessageId: "o1",
+    sourceChannelId: "c1",
+    repostChannelId: "c2",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+  const old = snowflakeAt(now - 200 * day);
+  const recent = snowflakeAt(now);
+  try {
+    saveRepost(guild, old, record);
+    saveRepost(guild, recent, record);
+    check(
+      "retention",
+      "saving a repost drops the expired records",
+      getRepost(guild, old) === undefined && getRepost(guild, recent) !== undefined,
+    );
+  } finally {
+    rmSync(path.join(ROOT, "data", guild), { recursive: true, force: true });
+  }
+
+  try {
+    recordReply(guild, old, { channelId: "c1", messageId: "r1" });
+    recordReply(guild, recent, { channelId: "c1", messageId: "r2" });
+    check(
+      "retention",
+      "recording a reply drops the expired links",
+      takeReplies(guild, old).length === 0 && takeReplies(guild, recent).length === 1,
+    );
+  } finally {
+    rmSync(path.join(ROOT, "data", guild), { recursive: true, force: true });
+  }
 }
 
 /**
@@ -1029,54 +1199,72 @@ function checkMemberPrefs(): void {
 }
 
 /**
- * Verifies who sees what. Discord filters the slash-command picker on a
- * command's default permissions, so the fully-admin commands carry Manage
- * Server and the mixed ones (open leaderboards, admin nuke) must not - the
- * filter is per command, not per subcommand. /help then has to agree with the
- * picker, or it advertises commands a member cannot reach.
+ * Verifies who sees what. Discord applies a command's default permissions
+ * before dispatching it, which would shut the bot owner out of the very
+ * commands the owner grant exists for, so no builder carries them and every
+ * admin command is authorised at runtime instead. /help then has to do the
+ * hiding, or it advertises commands a member can only be refused.
  */
 function checkCommandVisibility(): void {
-  const manageGuild = String(PermissionFlagsBits.ManageGuild);
-  for (const [label, builder] of [
-    ["/setdelay", setDelay],
-    ["/setmediachannel", setMediaChannel],
-    ["/calmdown", calmDown],
-  ] as const) {
-    check(
-      "perms",
-      `${label} is hidden from members without Manage Server`,
-      builder.toJSON().default_member_permissions === manageGuild,
-    );
-  }
-  for (const [label, builder] of [
-    ["/mydelay", myDelay],
-    ["/swears", swearsCommand],
-    ["/slurs", slursCommand],
-  ] as const) {
-    const perms = builder.toJSON().default_member_permissions;
-    check("perms", `${label} stays in everyone's picker`, perms === null || perms === undefined);
-  }
+  const builders = [setDelay, setMediaChannel, calmDown, myDelay, swearsCommand, slursCommand];
+  // Registering any default permission would silently reinstate the gate the
+  // owner grant cannot beat, so this is the invariant the rest rests on.
+  check(
+    "perms",
+    "no command registers a default member permission",
+    builders.every((b) => {
+      const perms = b.toJSON().default_member_permissions;
+      return perms === null || perms === undefined;
+    }),
+  );
+
+  // A renamed command that keeps its requireAdmin call but drops out of
+  // ADMIN_COMMANDS is open to everyone, and nothing else would say so.
+  const names = new Set(builders.map((b) => b.toJSON().name));
+  check(
+    "perms",
+    "every ADMIN_COMMANDS entry names a real command",
+    ADMIN_COMMANDS.every((name) => names.has(name)),
+  );
+  check(
+    "perms",
+    "every ADMIN_SUBCOMMANDS key names a real command",
+    Object.keys(ADMIN_SUBCOMMANDS).every((name) => names.has(name)),
+  );
+
+  // The gate the dispatcher calls, on the cases it has to tell apart.
+  check("perms", "the gate catches a wholly admin command", needsAdmin("setdelay", "instant"));
+  check("perms", "the gate catches an admin subcommand", needsAdmin("swears", "nuke"));
+  check("perms", "the gate lets an open subcommand through", !needsAdmin("swears", "top"));
+  check("perms", "the gate lets an open command with no subcommand through", !needsAdmin("help"));
 
   const asMember = buildHelpFields([setDelay.toJSON(), myDelay.toJSON()], false);
   const asAdmin = buildHelpFields([setDelay.toJSON(), myDelay.toJSON()], true);
   check(
     "perms",
-    "/help hides what the picker hides",
+    "/help hides admin commands from a member",
     !asMember.some((f) => f.name === "/setdelay") && asMember.some((f) => f.name === "/mydelay"),
   );
   check(
     "perms",
-    "/help still lists admin commands for an admin",
-    asAdmin.some((f) => f.name === "/setdelay"),
+    "/help lists admin commands to an admin, marked",
+    asAdmin.some((f) => f.name === "/setdelay 🔒") && asAdmin.some((f) => f.name === "/mydelay"),
   );
 
-  // A command the picker cannot filter has to say so line by line.
-  const swears = buildHelpFields([swearsCommand.toJSON()], false)[0].value.split(/\r?\n/);
+  // A command open to everyone bar one subcommand is filtered line by line.
+  const swearsAsMember = buildHelpFields([swearsCommand.toJSON()], false)[0].value.split(/\r?\n/);
   check(
     "perms",
-    "/help marks the admin subcommand of a shared command",
-    swears.some((line) => line.includes("nuke") && line.includes("🔒")) &&
-      swears.some((line) => line.includes("top") && !line.includes("🔒")),
+    "/help drops the admin subcommand of a shared command for a member",
+    !swearsAsMember.some((line) => line.includes("nuke")) &&
+      swearsAsMember.some((line) => line.includes("top")),
+  );
+  const swearsAsAdmin = buildHelpFields([swearsCommand.toJSON()], true)[0].value.split(/\r?\n/);
+  check(
+    "perms",
+    "/help marks the admin subcommand of a shared command for an admin",
+    swearsAsAdmin.some((line) => line.includes("nuke") && line.includes("🔒")) &&
+      swearsAsAdmin.some((line) => line.includes("top") && !line.includes("🔒")),
   );
 }
 
@@ -1107,7 +1295,9 @@ void (async () => {
     checkCommandVisibility();
     checkLinkTransforms();
     checkRepostContent();
+    await checkRepostOrdering();
     checkRepostStore();
+    checkRetention();
     checkReactions();
     checkGrace();
     checkMemberPrefs();

--- a/src/commands/calmdown.ts
+++ b/src/commands/calmdown.ts
@@ -12,7 +12,7 @@ import { createLogger } from "@/utils/log";
 import { requireAdmin } from "@/utils/permissions";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { InteractionContextType } from "discord-api-types/v10";
-import { ChatInputCommandInteraction, MessageFlags, PermissionFlagsBits } from "discord.js";
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
 
 const log = createLogger("cmd/calmdown");
 
@@ -52,7 +52,6 @@ export const data = new SlashCommandBuilder()
           .setMaxValue(1000),
       ),
   )
-  .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
   .setContexts(InteractionContextType.Guild);
 
 /**

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,6 +1,6 @@
 // src/commands/help.ts
 
-import { ADMIN_SUBCOMMANDS, isAdmin } from "@/utils/permissions";
+import { ADMIN_COMMANDS, ADMIN_SUBCOMMANDS, isAdmin } from "@/utils/permissions";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import {
   APIEmbedField,
@@ -21,11 +21,11 @@ export const data = new SlashCommandBuilder()
   .setContexts(InteractionContextType.Guild);
 
 /**
- * Builds the embed fields listing commands. Commands carrying default
- * permissions are the ones Discord keeps out of a member's picker, so they are
- * left out here too for anyone who cannot run them - otherwise `/help`
- * advertises commands that are not there to be found. Commands that mix open
- * and admin subcommands stay listed, with the admin ones marked.
+ * Builds the embed fields listing commands. Discord filters nothing out of a
+ * member's picker any more, so this is the only place an admin-only command or
+ * subcommand gets hidden - otherwise `/help` advertises what will only refuse.
+ * A member sees neither an {@link ADMIN_COMMANDS} entry nor an
+ * {@link ADMIN_SUBCOMMANDS} line; an admin sees both, marked.
  * @param commands - The loaded commands, as Discord registered them.
  * @param admin - Whether the invoker may run admin commands.
  * @returns One field per command the invoker can see.
@@ -36,7 +36,8 @@ export function buildHelpFields(
 ): APIEmbedField[] {
   const fields: APIEmbedField[] = [];
   for (const json of commands) {
-    if (json.default_member_permissions && !admin) continue;
+    const adminOnly = ADMIN_COMMANDS.includes(json.name);
+    if (adminOnly && !admin) continue;
 
     // Right-click entries carry no description - Discord rejects one - and an
     // empty field value would be rejected too, so they get a fixed line saying
@@ -51,9 +52,14 @@ export function buildHelpFields(
     }
 
     const adminSubs = ADMIN_SUBCOMMANDS[json.name] ?? [];
-    const subs = ("options" in json ? (json.options ?? []) : []).filter(
+    const allSubs = ("options" in json ? (json.options ?? []) : []).filter(
       (o) => o.type === ApplicationCommandOptionType.Subcommand,
     );
+    const subs = admin ? allSubs : allSubs.filter((s) => !adminSubs.includes(s.name));
+    // Nothing left once the admin lines go: drop the command rather than fall
+    // through to the description, which would advertise it with no way in.
+    if (allSubs.length && !subs.length) continue;
+
     const value = subs.length
       ? subs
           .map((s) => {
@@ -62,7 +68,10 @@ export function buildHelpFields(
           })
           .join("\n")
       : ("description" in json ? json.description : "") || "-";
-    fields.push({ name: `/${json.name}`, value, inline: false });
+    // Only an admin ever sees this, and the mark tells them which of the
+    // commands listed a member would be refused on.
+    const name = adminOnly ? `/${json.name} ${ADMIN_MARK}` : `/${json.name}`;
+    fields.push({ name, value, inline: false });
   }
   return fields;
 }
@@ -80,8 +89,8 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
   const fields = buildHelpFields(commands, isAdmin(interaction));
 
   const embed = new EmbedBuilder().setTitle("Commands").setColor(0x5865f2).addFields(fields);
-  if (fields.some((f) => f.value.includes(ADMIN_MARK))) {
-    embed.setFooter({ text: `${ADMIN_MARK} needs Manage Server` });
+  if (fields.some((f) => f.name.includes(ADMIN_MARK) || f.value.includes(ADMIN_MARK))) {
+    embed.setFooter({ text: `${ADMIN_MARK} admin only - a member can't run this` });
   }
   await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
 }

--- a/src/commands/mydelay.ts
+++ b/src/commands/mydelay.ts
@@ -77,7 +77,7 @@ export function resolvePref(mode: MemberMode, seconds?: number | null): MemberPr
 function describeGuildDefault(grace: GraceSetting | undefined): string {
   const g = grace ?? 10_000;
   if (g === "instant") return "your links get moved straight away";
-  if (g === "disabled") return "you get asked, and the prompt waits forever";
+  if (g === "disabled") return "you get asked, and the prompt stays up for a day";
   return `you get ${Math.round((g as number) / 1000)}s to hit Yes before the prompt gives up`;
 }
 

--- a/src/commands/setdelay.ts
+++ b/src/commands/setdelay.ts
@@ -7,7 +7,7 @@ import { createLogger } from "@/utils/log";
 import { requireAdmin } from "@/utils/permissions";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { InteractionContextType } from "discord-api-types/v10";
-import { ChatInputCommandInteraction, MessageFlags, PermissionFlagsBits } from "discord.js";
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
 
 const log = createLogger("cmd/setdelay");
 
@@ -16,7 +16,7 @@ const log = createLogger("cmd/setdelay");
  * self-explanatory - no mode/value combination to get wrong:
  * - `/setdelay instant` - move links immediately, no prompt
  * - `/setdelay seconds seconds:<1-300>` - prompt that times out
- * - `/setdelay disabled` - prompt that waits forever
+ * - `/setdelay disabled` - prompt that stays up for a day
  *
  * `/setdelay personal` sits alongside them, governing what members may pick
  * for themselves with `/mydelay` rather than the default itself.
@@ -41,7 +41,7 @@ export const data = new SlashCommandBuilder()
       ),
   )
   .addSubcommand((sub) =>
-    sub.setName("disabled").setDescription("Always ask, and wait forever for an answer"),
+    sub.setName("disabled").setDescription("Always ask, and leave the prompt up for a day"),
   )
   .addSubcommand((sub) =>
     sub
@@ -61,7 +61,6 @@ export const data = new SlashCommandBuilder()
         opt.setName("allow-never").setDescription("Let members opt out of moves entirely"),
       ),
   )
-  .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
   .setContexts(InteractionContextType.Guild);
 
 /**
@@ -147,7 +146,7 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     const confirmations: Record<"instant" | "seconds" | "disabled", string> = {
       instant: "✅ Links get moved straight away now, no prompt.",
       seconds: `✅ Posters get ${seconds}s to hit Yes or No before the prompt gives up.`,
-      disabled: "✅ Posters always get asked, and the prompt waits forever.",
+      disabled: "✅ Posters always get asked, and the prompt stays up for a day.",
     };
     await interaction.reply({ content: confirmations[mode], flags: MessageFlags.Ephemeral });
   } catch (err) {

--- a/src/commands/setmediachannel.ts
+++ b/src/commands/setmediachannel.ts
@@ -5,13 +5,7 @@ import { createLogger } from "@/utils/log";
 import { requireAdmin } from "@/utils/permissions";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { InteractionContextType } from "discord-api-types/v10";
-import {
-  ChannelType,
-  ChatInputCommandInteraction,
-  MessageFlags,
-  PermissionFlagsBits,
-  TextChannel,
-} from "discord.js";
+import { ChannelType, ChatInputCommandInteraction, MessageFlags, TextChannel } from "discord.js";
 
 const log = createLogger("cmd/setmediachannel");
 
@@ -29,7 +23,6 @@ export const data = new SlashCommandBuilder()
       .addChannelTypes(ChannelType.GuildText)
       .setRequired(true),
   )
-  .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
   .setContexts(InteractionContextType.Guild);
 
 /**
@@ -49,12 +42,12 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
   const guildId = interaction.guildId;
   const userId = interaction.user.id;
 
-  log.debug("invoked", { guildId, userId, targetChannelId: channel.id });
-
   if (!(await requireAdmin(interaction))) {
     log.warn("permission denied", { guildId, userId });
     return;
   }
+
+  log.debug("invoked", { guildId, userId, targetChannelId: channel.id });
 
   try {
     const settings = loadSettings(guildId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { onMessage, onMessageEdit } from "@/onMessage";
 import { onMessageDelete } from "@/onMessageDelete";
 import type { CommandModule } from "@/types/discord";
 import { createLogger } from "@/utils/log";
+import { gateAutocomplete, gateCommand } from "@/utils/permissions";
 import { REST } from "@discordjs/rest";
 import { RESTPostAPIApplicationCommandsJSONBody, Routes } from "discord-api-types/v10";
 import {
@@ -177,6 +178,10 @@ client.on("interactionCreate", async (interaction: Interaction) => {
     return;
   }
   if (interaction.isAutocomplete()) {
+    if (!gateAutocomplete(interaction)) {
+      await interaction.respond([]).catch(() => undefined);
+      return;
+    }
     const cmd = client.commands.get(interaction.commandName);
     await cmd?.autocomplete?.(interaction).catch((err) => {
       log.error("autocomplete failed", {
@@ -190,6 +195,14 @@ client.on("interactionCreate", async (interaction: Interaction) => {
   const cmd = client.commands.get(interaction.commandName);
   if (!cmd) return;
   try {
+    if (interaction.isChatInputCommand() && !(await gateCommand(interaction))) {
+      log.warn("command refused", {
+        command: interaction.commandName,
+        guildId: interaction.guildId,
+        userId: interaction.user.id,
+      });
+      return;
+    }
     await cmd.execute(interaction);
   } catch (err) {
     log.error("command execution error", {

--- a/src/media/approval.ts
+++ b/src/media/approval.ts
@@ -18,6 +18,16 @@ import {
 
 const log = createLogger("media/approval");
 
+/**
+ * How long a `"disabled"` (no-timeout) prompt actually stays live. Each one
+ * holds a collector and an unresolved promise for its whole life, so "waits
+ * for an answer" cannot mean literally forever - an unanswered prompt would
+ * pin both until the process restarts. A day is far longer than anyone takes
+ * to answer, and a prompt still up after one is abandoned: the buttons come
+ * off and the link is left alone.
+ */
+export const INDEFINITE_PROMPT_MS = 24 * 60 * 60_000;
+
 /** One button in a {@link requestChoice} prompt. */
 export interface ChoiceButton {
   /** Custom ID, unique within this prompt; returned as the choice. */
@@ -82,7 +92,7 @@ async function answerClick(i: ButtonInteraction, privateReply?: string): Promise
  * Ask `author` to pick one of `buttons` in `channel`.
  * - Only `author` clicks are accepted; everyone else's are ignored.
  * - `grace: "instant"` resolves to `opts.instantChoice` without showing UI.
- *   `"disabled"` waits indefinitely.
+ *   `"disabled"` waits {@link INDEFINITE_PROMPT_MS} rather than on a grace.
  * - A button in `opts.privateReplies` answers the clicker ephemerally.
  * - On end: deletes the prompt if `autoDelete` and `grace !== "disabled"`,
  *   else strips the buttons so it cannot be clicked later.
@@ -137,7 +147,7 @@ export async function requestChoice(
     typeof grace === "number" && Number.isFinite(grace) && grace >= 0
       ? grace
       : grace === "disabled"
-        ? undefined
+        ? INDEFINITE_PROMPT_MS
         : 10_000;
 
   const ids = new Set(buttons.map((b) => b.id));

--- a/src/media/repost.ts
+++ b/src/media/repost.ts
@@ -50,15 +50,17 @@ export function buildPointerContent(
 }
 
 /**
- * Delete the original, post the embeddable rewrite in the target channel
- * (carrying over any attachments), and optionally leave a pointer back in the
- * source channel.
+ * Post the embeddable rewrite in the target channel (carrying over any
+ * attachments), delete the original, and optionally leave a pointer back in
+ * the source channel. In that order, so a failed post leaves the poster's
+ * message where it is rather than losing it.
  * @param original The original guild message to move.
  * @param rewrittenText The rewritten content where the first URL is the transformed (embeddable) link.
  * @param source Source channel.
  * @param target Target channel.
  * @param withStub When true and channels differ, leave a pointer in the source channel.
- * @returns The moved message, optional pointer, and link URL.
+ * @returns The moved message, optional pointer, and link URL; all empty when
+ * the post could not be made and nothing was moved.
  */
 export async function repostWithOptionalStub(
   original: Message<true>,
@@ -68,16 +70,8 @@ export async function repostWithOptionalStub(
   withStub: boolean,
 ): Promise<RepostOutcome> {
   const authorMention = `<@${original.author.id}>`;
-
-  // Capture attachment URLs before deleting the original: the signed CDN
-  // links stay valid after deletion, long enough to re-upload the files with
-  // the moved message so images/videos survive the move.
   const files = [...original.attachments.values()].map((a) => a.url);
-
   const mentions = collectMentions(original.content, original.author.id);
-
-  await original.delete().catch(() => {});
-  log.debug("deleted original", { originalId: original.id });
 
   // Post the rewrite (with the embeddable link) so Discord renders the embed.
   // Empty allowedMentions: the author's @ renders in the text without pinging.
@@ -88,34 +82,58 @@ export async function repostWithOptionalStub(
     allowedMentions: { parse: [] },
   } satisfies Parameters<TextChannel["send"]>[0];
 
-  let moved: Message<true>;
-  if (files.length === 0) {
-    moved = await (target as TextChannel).send(payload);
-  } else {
-    try {
-      moved = await (target as TextChannel).send({ ...payload, files });
-    } catch (err) {
-      // Re-upload can fail (e.g. a file over the bot's upload limit); fall
-      // back to appending the CDN links so nothing is silently lost.
-      log.warn("attachment re-upload failed, linking instead", {
-        count: files.length,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      moved = await (target as TextChannel).send({
-        ...payload,
-        content: `${payload.content}\n${files.join("\n")}`,
-      });
-    }
+  // The original is deleted only once the replacement is up. A send can fail
+  // for reasons the caller cannot rule out in advance - the prefix pushing a
+  // near-limit message past 2000 characters, a missing permission in the
+  // target - and deleting first would destroy the poster's message with
+  // nothing put back in its place.
+  let moved: Message<true> | undefined;
+  try {
+    moved = await (target as TextChannel).send(files.length ? { ...payload, files } : payload);
+  } catch (err) {
+    log.warn("repost send failed", {
+      targetId: target.id,
+      files: files.length,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  if (!moved && files.length) {
+    // Re-upload can fail on its own (e.g. a file over the bot's upload
+    // limit); fall back to appending the CDN links so nothing is lost.
+    moved = await (target as TextChannel)
+      .send({ ...payload, content: `${payload.content}\n${files.join("\n")}` })
+      .catch(() => undefined);
+  }
+  if (!moved) {
+    log.error("repost failed, original left in place", {
+      targetId: target.id,
+      originalId: original.id,
+    });
+    return {};
   }
   log.info("posted moved message", { movedId: moved.id, targetId: target.id });
 
+  await original.delete().catch(() => {});
+  log.debug("deleted original", { originalId: original.id });
+
+  // A pointer that will not send is cosmetic - the move itself has already
+  // happened, so it must not take the caller's registration down with it.
   let stub: Message<true> | undefined;
   if (withStub && source.id !== target.id) {
-    stub = await source.send({
-      content: buildPointerContent(authorMention, mentions, moved.url),
-      allowedMentions: { parse: [] },
-    });
-    log.debug("posted pointer", { stubId: stub.id, sourceId: source.id });
+    stub =
+      (await source
+        .send({
+          content: buildPointerContent(authorMention, mentions, moved.url),
+          allowedMentions: { parse: [] },
+        })
+        .catch((err: unknown) => {
+          log.warn("pointer send failed", {
+            sourceId: source.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return undefined;
+        })) ?? undefined;
+    if (stub) log.debug("posted pointer", { stubId: stub.id, sourceId: source.id });
   }
 
   return { moved, stub, linkUrl: moved.url };

--- a/src/media/repostActions.ts
+++ b/src/media/repostActions.ts
@@ -125,8 +125,24 @@ function splitMovedContent(content: string): { prefix: string; text: string } {
 }
 
 /**
+ * Resolves a channel by ID. Fetched rather than read off the cache: a thread
+ * that has since been archived drops out of it, and a cache miss here reads as
+ * "the post is gone" on a post that is still sitting there.
+ * @param interaction - Any interaction, used for its client.
+ * @param channelId - The channel to resolve.
+ * @returns The channel, or `null` when it is gone or unreachable.
+ */
+async function fetchTextChannel(
+  interaction: RepliableInteraction,
+  channelId: string,
+): Promise<GuildTextBasedChannel | null> {
+  const channel = await interaction.client.channels.fetch(channelId).catch(() => null);
+  return channel?.isTextBased() ? (channel as GuildTextBasedChannel) : null;
+}
+
+/**
  * Fetches a moved message from the channel its record names.
- * @param interaction - Any interaction, used for its client channel cache.
+ * @param interaction - Any interaction, used for its client.
  * @param record - The stored record naming the repost channel.
  * @param movedMessageId - ID of the moved message to fetch.
  * @returns The message, or `null` when it is gone or unreachable.
@@ -136,8 +152,7 @@ async function fetchMoved(
   record: RepostRecord,
   movedMessageId: string,
 ): Promise<Message | null> {
-  const channel = interaction.client.channels.cache.get(record.repostChannelId) as
-    GuildTextBasedChannel | undefined;
+  const channel = await fetchTextChannel(interaction, record.repostChannelId);
   return (await channel?.messages.fetch(movedMessageId).catch(() => null)) ?? null;
 }
 
@@ -172,8 +187,7 @@ async function deleteRepost(
   await moved?.delete().catch(() => {});
 
   if (record.stubMessageId) {
-    const channel = interaction.client.channels.cache.get(record.sourceChannelId) as
-      GuildTextBasedChannel | undefined;
+    const channel = await fetchTextChannel(interaction, record.sourceChannelId);
     const stub = await channel?.messages.fetch(record.stubMessageId).catch(() => null);
     await stub?.delete().catch(() => {});
   }
@@ -311,8 +325,20 @@ export async function handleRepostEditModal(interaction: ModalSubmitInteraction)
     return;
   }
 
+  // An unanswered modal submit shows the author a bare "something went wrong",
+  // so a failed edit has to be reported rather than thrown past them.
   const { prefix } = splitMovedContent(moved.content);
-  await moved.edit({ content: `${prefix}\n\n${newText}`, allowedMentions: { parse: [] } });
+  try {
+    await moved.edit({ content: `${prefix}\n\n${newText}`, allowedMentions: { parse: [] } });
+  } catch (err) {
+    log.warn("failed to edit repost", {
+      guildId: interaction.guildId,
+      movedId: owned.movedMessageId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    await notify(interaction, "⚠️ That edit wouldn't go through - the post is unchanged.");
+    return;
+  }
   await notify(interaction, "✅ Updated.");
   log.info("author edited repost", {
     guildId: interaction.guildId,

--- a/src/media/repostStore.ts
+++ b/src/media/repostStore.ts
@@ -7,6 +7,7 @@
 
 import { loadData, saveData } from "@/utils/file";
 import { createLogger } from "@/utils/log";
+import { pruneByKeyAge, REPOST_RETENTION_MS } from "@/utils/retention";
 
 const log = createLogger("media/repostStore");
 
@@ -47,9 +48,13 @@ function loadMap(guildId: string): RepostMap {
  * @param record - The {@link RepostRecord} to persist.
  */
 export function saveRepost(guildId: string, movedMessageId: string, record: RepostRecord): void {
-  const map = loadMap(guildId);
-  map[movedMessageId] = record;
-  saveData(guildId, REPOSTS_FILE, map);
+  // Pruned on write: a record is only ever removed when its own post is, so
+  // without this the map grows for the life of the guild and every stub
+  // lookup scans the lot.
+  const { kept, dropped } = pruneByKeyAge(loadMap(guildId), REPOST_RETENTION_MS);
+  kept[movedMessageId] = record;
+  saveData(guildId, REPOSTS_FILE, kept);
+  if (dropped > 0) log.info("pruned expired repost records", { guildId, dropped });
   log.debug("saved repost record", { guildId, movedMessageId });
 }
 
@@ -74,9 +79,9 @@ export interface RepostLookup {
 /**
  * Resolves the repost a message belongs to, whether it is the moved message
  * itself or the pointer stub left behind in the source channel. The map is
- * keyed by moved-message ID, so the stub match is a scan - a guild holds one
- * record per moved link, which stays small enough not to warrant a second
- * index.
+ * keyed by moved-message ID, so the stub match is a scan - saves prune to
+ * {@link REPOST_RETENTION_MS}, which keeps it to one record per link moved in
+ * the window, too few to warrant a second index.
  * @param guildId - Discord guild ID.
  * @param messageId - ID of the message the user acted on.
  * @returns The {@link RepostLookup}, or `undefined` when the message is neither.

--- a/src/media/transform.ts
+++ b/src/media/transform.ts
@@ -91,16 +91,20 @@ export function rewriteContent(
   authorId?: string,
 ): RewriteResult {
   const newLink = buildTransformedUrl(match, authorId);
+  // Inserted through a function, never as a replacement string: "$&", "$'" and
+  // "$1" are substitution patterns there, and the link carries whatever the
+  // poster's URL path held, so a "$" in it would rewrite to something else.
+  const insert = (): string => newLink;
   let rewrittenText: string;
   if (match.literal) {
     // Tracking matches carry the exact URL - replace it as a plain string.
-    rewrittenText = content.replace(match.literal, newLink);
+    rewrittenText = content.replace(match.literal, insert);
   } else {
     // Also consume any query/fragment trailing the matched URL - on social
     // links that tail is share-tracking junk (?s=20&t=...) which would
     // otherwise stay glued to the rewritten link.
     const consuming = new RegExp(`${match.regex.source}(?:[?#]\\S*)?`, match.regex.flags);
-    rewrittenText = content.replace(consuming, newLink);
+    rewrittenText = content.replace(consuming, insert);
   }
   log.debug("rewrote content", { which: match.which, newLink });
   return { newLink, rewrittenText };

--- a/src/media/workflow.ts
+++ b/src/media/workflow.ts
@@ -85,9 +85,14 @@ export async function handleMediaMessage(message: Message): Promise<void> {
   const source = message.channel as GuildTextBasedChannel;
   // Tracking cleans are not media: the link stays in its channel, cleaned.
   const isTrackingClean = match.which === "tracking";
-  const target = isTrackingClean
-    ? source
-    : ((message.client.channels.cache.get(targetId) ?? source) as GuildTextBasedChannel);
+  // Fetched rather than read off the cache: an uncached media channel would
+  // fall back to the source and quietly turn a move into a same-channel
+  // rewrite, which is a different prompt and a different outcome.
+  const configured =
+    isTrackingClean || targetId === source.id
+      ? null
+      : await message.client.channels.fetch(targetId).catch(() => null);
+  const target = (configured as GuildTextBasedChannel | null) ?? source;
 
   const sameChannel = source.id === target.id;
 

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -12,12 +12,19 @@ import {
 const BOT_OWNER_ID = process.env.YOUR_ID;
 
 /**
+ * Commands that need admin from end to end. No builder carries default member
+ * permissions: Discord applies those before dispatching, which would keep the
+ * bot-owner grant in {@link isAdmin} from ever being consulted for an owner
+ * without Manage Server. Authorisation is {@link requireAdmin} at runtime
+ * instead, and `/help` uses this list to keep them out of a member's listing.
+ */
+export const ADMIN_COMMANDS: string[] = ["calmdown", "setdelay", "setmediachannel"];
+
+/**
  * Subcommands that need admin on commands that are otherwise open to everyone,
- * keyed by command name. Discord filters its picker per command rather than
- * per subcommand, so these cannot be hidden the way a fully-admin command is;
- * `/help` marks them instead. Keep in step with the {@link requireAdmin} calls
- * in the command modules - a fully-admin command belongs in its builder's
- * default permissions, not here.
+ * keyed by command name. `/help` drops these lines for a member rather than the
+ * whole command, and marks them for an admin. Keep both lists in step with the
+ * {@link requireAdmin} calls in the command modules.
  */
 export const ADMIN_SUBCOMMANDS: Record<string, string[]> = {
   slurs: ["nuke"],
@@ -29,7 +36,7 @@ export const ADMIN_SUBCOMMANDS: Record<string, string[]> = {
  * Allowed: the bot owner ({@link BOT_OWNER_ID}), the guild owner, or a member
  * with Manage Server (Administrator implies it). Runtime check rather than
  * Discord default permissions so the bot-owner grant works for members
- * without Manage Server.
+ * without Manage Server - see {@link ADMIN_COMMANDS}.
  *
  * Autocomplete interactions are accepted too, so a command can tailor its
  * suggestions to what the invoker is allowed to act on.
@@ -62,4 +69,45 @@ export async function requireAdmin(interaction: ChatInputCommandInteraction): Pr
     flags: MessageFlags.Ephemeral,
   });
   return false;
+}
+
+/**
+ * Whether an invocation needs admin, by name. Covers both a wholly admin
+ * command ({@link ADMIN_COMMANDS}) and an admin subcommand of an open one
+ * ({@link ADMIN_SUBCOMMANDS}).
+ * @param command - The command name, without the leading slash.
+ * @param subcommand - The chosen subcommand, or null when there is none.
+ * @returns `true` when the invocation is admin-only.
+ */
+export function needsAdmin(command: string, subcommand?: string | null): boolean {
+  if (ADMIN_COMMANDS.includes(command)) return true;
+  return subcommand !== null && subcommand !== undefined
+    ? (ADMIN_SUBCOMMANDS[command] ?? []).includes(subcommand)
+    : false;
+}
+
+/**
+ * Authorises a command before it is dispatched. Nothing is registered with
+ * default member permissions, so Discord hands every command to every member
+ * and this is the gate that stops one - a command module's own
+ * {@link requireAdmin} call is a second layer, not the only one.
+ * @param interaction - The command interaction about to be dispatched.
+ * @returns `true` when the command may run, `false` when it was refused (a
+ * reply has already been sent).
+ */
+export async function gateCommand(interaction: ChatInputCommandInteraction): Promise<boolean> {
+  if (!needsAdmin(interaction.commandName, interaction.options.getSubcommand(false))) return true;
+  return requireAdmin(interaction);
+}
+
+/**
+ * Authorises an autocomplete request. Suggestions for an admin-only
+ * invocation would otherwise be served to anyone who can type the command,
+ * which is everyone now that Discord filters nothing.
+ * @param interaction - The autocomplete interaction about to be dispatched.
+ * @returns `true` when the suggestions may be built.
+ */
+export function gateAutocomplete(interaction: AutocompleteInteraction): boolean {
+  if (!needsAdmin(interaction.commandName, interaction.options.getSubcommand(false))) return true;
+  return isAdmin(interaction);
 }

--- a/src/utils/replyStore.ts
+++ b/src/utils/replyStore.ts
@@ -1,13 +1,14 @@
 // src/utils/replyStore.ts
 
 /**
- * @file Persists which bot replies are tied to which user message, so when
- * the trigger message is deleted the bot's replies can be deleted too - no
- * matter how old they are or how many restarts have happened since.
+ * @file Persists which bot replies are tied to which user message, so when the
+ * trigger message is deleted the bot's replies can be deleted too, across any
+ * number of restarts and up to {@link REPLY_RETENTION_MS} after the fact.
  */
 
 import { loadData, saveData } from "@/utils/file";
 import { createLogger } from "@/utils/log";
+import { pruneByKeyAge, REPLY_RETENTION_MS } from "@/utils/retention";
 
 const log = createLogger("utils/replyStore");
 
@@ -30,8 +31,12 @@ type ReplyMap = Record<string, ReplyRef[]>;
  */
 export function recordReply(guildId: string, triggerMessageId: string, ref: ReplyRef): void {
   const map = loadData<ReplyMap>(guildId, REPLIES_FILE, { soft: true, defaultValue: {} });
-  map[triggerMessageId] = [...(map[triggerMessageId] ?? []), ref];
-  saveData(guildId, REPLIES_FILE, map);
+  // Pruned on write: an entry is only ever released when its trigger message
+  // is deleted, and most never are, so the map would grow without bound.
+  const { kept, dropped } = pruneByKeyAge(map, REPLY_RETENTION_MS);
+  kept[triggerMessageId] = [...(kept[triggerMessageId] ?? []), ref];
+  saveData(guildId, REPLIES_FILE, kept);
+  if (dropped > 0) log.info("pruned expired reply links", { guildId, dropped });
   log.debug("recorded reply", { guildId, triggerMessageId, replyId: ref.messageId });
 }
 

--- a/src/utils/retention.ts
+++ b/src/utils/retention.ts
@@ -1,0 +1,54 @@
+// src/utils/retention.ts
+
+// Age-based pruning for the message-keyed stores. Both are keyed by a Discord
+// message ID, and a snowflake carries its own creation time, so an entry's age
+// is readable from the key alone - nothing has to be stamped beside it, and
+// records written before this existed prune on the same rule as new ones.
+
+/** Start of Discord's snowflake epoch (2015-01-01), in epoch ms. */
+const DISCORD_EPOCH = 1_420_070_400_000;
+
+/** How long a moved post stays editable/deletable by its author. */
+export const REPOST_RETENTION_MS = 90 * 24 * 60 * 60_000;
+
+/** How long a bot reply stays linked to the message that triggered it. */
+export const REPLY_RETENTION_MS = 30 * 24 * 60 * 60_000;
+
+/**
+ * Reads the creation time out of a Discord snowflake. The timestamp is the top
+ * 42 bits, counted from {@link DISCORD_EPOCH} rather than the Unix one.
+ * @param id - A Discord message, channel or user ID.
+ * @returns Epoch ms, or `null` when the string is not a snowflake.
+ */
+export function snowflakeTime(id: string): number | null {
+  if (!/^\d{17,20}$/.test(id)) return null;
+  return Number(BigInt(id) >> 22n) + DISCORD_EPOCH;
+}
+
+/**
+ * Drops the entries of a message-keyed map whose keys name messages older than
+ * the retention window. A key that is not a snowflake is kept: its age cannot
+ * be read, and silently discarding an entry nobody can date would lose more
+ * than it saves.
+ * @param map - The store to prune. Not mutated.
+ * @param maxAgeMs - How long an entry is kept, from its key's message time.
+ * @param now - Epoch ms to measure against; defaults to the current time.
+ * @returns The surviving entries and how many were dropped.
+ */
+export function pruneByKeyAge<T>(
+  map: Record<string, T>,
+  maxAgeMs: number,
+  now: number = Date.now(),
+): { kept: Record<string, T>; dropped: number } {
+  const kept: Record<string, T> = {};
+  let dropped = 0;
+  for (const [key, value] of Object.entries(map)) {
+    const created = snowflakeTime(key);
+    if (created !== null && now - created > maxAgeMs) {
+      dropped++;
+      continue;
+    }
+    kept[key] = value;
+  }
+  return { kept, dropped };
+}


### PR DESCRIPTION
`/setdelay`, `/setmediachannel` and `/calmdown` registered Manage Server as their default permission. Discord applies those before dispatching an interaction, so the `YOUR_ID` owner grant, a runtime check Discord knows nothing about, was never consulted: a bot owner holding neither ownership nor Manage Server could not see the commands at all. Which is how this started, and the sweep that followed found the rest.

## Admin commands

The default permissions come off. Every admin command is authorised at runtime instead, once centrally in the interaction dispatcher through a new `gateCommand`, and again inside the command through the `requireAdmin` calls that were already there. `ADMIN_COMMANDS` now enforces rather than only feeding the help text, and `gateAutocomplete` covers autocomplete, which Discord's gate had been keeping off members by accident.

The trade-off is that the three sit in everyone's slash-command picker; a member who runs one is refused. `/help` does the hiding Discord no longer does, dropping both those commands and the admin subcommands of an otherwise open one (`/slurs nuke`, `/swears nuke`) rather than marking those for everyone. An admin sees both, marked 🔒.

## A failed move was losing the post

`repostWithOptionalStub` deleted the poster's message before sending the replacement, so any failed send destroyed it with nothing put back. Reachable two ways: the `from <@id>` prefix pushes a message near the 2000-character cap over it, and a missing permission in the target does the same. It now posts first and deletes only once the replacement is up, returning an empty outcome so the original stays where it is.

The pointer send is caught as well. A cosmetic failure was taking the caller's `registerRepostActions` down with it, leaving a moved post nobody could edit or delete.

## Channels are fetched, not read off the cache

An archived thread drops out of the client cache, which read as "that post is gone" on a post still sitting there. In the delete path the record and audit log were already written by that point, orphaning the message for good. An uncached media channel also fell back to the source channel and quietly turned a cross-channel move into a same-channel rewrite, which is a different prompt and a different outcome.

## Smaller fixes

A failed edit from the modal now answers the author instead of leaving the submit unanswered, which shows as a bare "something went wrong".

`rewriteContent` inserts the rewritten link through a function replacer. `$&`, `$'` and `$1` are substitution patterns in a replacement string, and a URL path may hold them: a tracking clean on `https://example.com/a$&b?utm_source=x` was rewriting to `https://example.com/abhttps://example.com/a$&b?utm_source=xb`.

## Stores that grew forever

`reposts.json` and `bot_replies.json` were only ever pruned when the specific message was deleted, and most never are. Saves now age entries out against the message ID's own snowflake timestamp, so nothing had to be stamped beside the record and existing files prune on the same rule: 90 days for a moved post, 30 for a reply link. That also bounds the stub scan in `findRepostForMessage`, which its own comment had been hand-waving about.

A `"disabled"` grace no longer means literally forever. Each prompt held a collector and an unresolved promise for its whole life, so it caps at a day, after which the buttons come off and the link is left alone. It only ever meant "until the next restart" anyway, since collectors are in memory.

## Verification

Minor bump to 2.11.0. `npm run typecheck`, `npm run lint`, `npm run build` and all 178 smoke checks pass, up from 166, with new coverage for the gate, the move's ordering, the `$` escape and retention. The ordering, `$` and retention checks were each confirmed to fail against the unfixed code. Not exercised against a live server.
